### PR TITLE
use #!/usr/bin/env bash and fix doc

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -45,7 +45,7 @@ sh /usr/local/oceanbase-diagnostic-tool/init.sh
 
 ```shell
 pip3 install -r requirements3.txt
-sh dev_init.sh
+./dev_init.sh
 source ~/.bashrc
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To install obdiag on Python >= 3.8, run these commands:
 
 ```shell
 pip3 install -r requirements3.txt
-sh dev_init.sh
+./dev_init.sh
 source ~/.bashrc
 ```
 

--- a/dev_init.sh
+++ b/dev_init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PROJECT_PATH=$(cd "$(dirname "$0")"; pwd)
 WORK_DIR=$(readlink -f "$(dirname ${BASH_SOURCE[0]})")

--- a/init.sh
+++ b/init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ $# == 1 && $1 == "-f" ]]; then
     FORCE_DEPLOY="1"

--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 python_bin='python'
 W_DIR=`pwd`

--- a/rpm/obdiag-build.sh
+++ b/rpm/obdiag-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PROJECT_DIR=$1
 PROJECT_NAME=$2


### PR DESCRIPTION
ubuntu
❯ sh dev_init.sh
dev_init.sh: 4: Bad substitution
dev_init.sh: 12: Syntax error: redirection unexpected

我研究了下，貌似ubuntu默认sh是dash
https://unix.stackexchange.com/questions/442510/how-to-use-bash-for-sh-in-ubuntu

有多个程序实现了 的语言 /bin/sh 。在 Ubuntu 上， /bin/sh 是 dash，它被设计为快速，使用少量内存，并且不支持超过预期的最低限度 /bin/sh 。在 RHEL 上， /bin/sh 是 bash，它速度较慢，使用更多内存，但具有更多功能。其中一个功能是 [ 条件语法的 == 运算符。Dash 支持 [ ，这是一个基本的 sh 功能，但它没有作为 bash（以及 ksh 和 zsh）扩展的 == 运算符。


Since Ubuntu 22.10 and Debian 12, this is no longer supported; if you want to switch /bin/sh to /bin/bash, you’ll have to symlink it manually. See [Gilles’ answer](https://unix.stackexchange.com/a/442518/86440) for details.
从 Ubuntu 22.10 和 Debian 12 开始，不再支持此功能;如果要切换 /bin/sh 到 /bin/bash ，则必须手动对其进行符号链接。有关详细信息，请参阅 Gilles 的回答。
