### PR TITLE
fix: When the reply message cannot be encoded by UTF-8, return the original message directly

### DIFF
--- a/common/ssh_client/local_client.py
+++ b/common/ssh_client/local_client.py
@@ -26,6 +26,7 @@ class LocalClient(SsherClient):
         super().__init__(context, node)
 
     def exec_cmd(self, cmd):
+        stdout, stderr = None, None
         try:
             self.stdio.verbose("[local host] run cmd = [{0}] on localhost".format(cmd))
             out = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, executable='/bin/bash')
@@ -35,8 +36,6 @@ class LocalClient(SsherClient):
             return stdout.decode('utf-8')
         except UnicodeDecodeError as e:
             self.stdio.warn("[localhost] Execute Shell command UnicodeDecodeError, command=[{0}]  Exception = [{1}]".format(cmd, e))
-            out = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, executable='/bin/bash')
-            stdout, stderr = out.communicate()
             if stderr:
                 return str(stderr)
             return str(stdout)

--- a/common/ssh_client/local_client.py
+++ b/common/ssh_client/local_client.py
@@ -33,6 +33,13 @@ class LocalClient(SsherClient):
             if stderr:
                 return stderr.decode('utf-8')
             return stdout.decode('utf-8')
+        except UnicodeDecodeError as e:
+            self.stdio.warn("[localhost] Execute Shell command UnicodeDecodeError, command=[{0}]  Exception = [{1}]".format(cmd, e))
+            out = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, executable='/bin/bash')
+            stdout, stderr = out.communicate()
+            if stderr:
+                return str(stderr)
+            return str(stdout)
         except Exception as e:
             self.stdio.error("run cmd = [{0}] on localhost, Exception = [{1}]".format(cmd, e))
             raise Exception("[localhost] Execute Shell command failed, command=[{0}]  Exception = [{1}]".format(cmd, e))

--- a/common/ssh_client/local_client.py
+++ b/common/ssh_client/local_client.py
@@ -33,7 +33,9 @@ class LocalClient(SsherClient):
             stdout, stderr = out.communicate()
             if stderr:
                 return stderr.decode('utf-8')
-            return stdout.decode('utf-8')
+            if stdout:
+                return stdout.decode('utf-8')
+            return ""
         except UnicodeDecodeError as e:
             self.stdio.warn("[localhost] Execute Shell command UnicodeDecodeError, command=[{0}]  Exception = [{1}]".format(cmd, e))
             if stderr:

--- a/common/ssh_client/local_client.py
+++ b/common/ssh_client/local_client.py
@@ -38,7 +38,9 @@ class LocalClient(SsherClient):
             self.stdio.warn("[localhost] Execute Shell command UnicodeDecodeError, command=[{0}]  Exception = [{1}]".format(cmd, e))
             if stderr:
                 return str(stderr)
-            return str(stdout)
+            if stdout:
+                return str(stdout)
+            return ""
         except Exception as e:
             self.stdio.error("run cmd = [{0}] on localhost, Exception = [{1}]".format(cmd, e))
             raise Exception("[localhost] Execute Shell command failed, command=[{0}]  Exception = [{1}]".format(cmd, e))

--- a/common/ssh_client/remote_client.py
+++ b/common/ssh_client/remote_client.py
@@ -78,6 +78,7 @@ class RemoteClient(SsherClient):
             self._ssh_fd.connect(hostname=self.host_ip, username=self.username, password=self.password, port=self.ssh_port, disabled_algorithms=self._disabled_rsa_algorithms)
 
     def exec_cmd(self, cmd):
+        stdin, stdout, stderr = None, None, None
         try:
             if self.remote_client_sudo:
                 # check sudo without password
@@ -96,7 +97,6 @@ class RemoteClient(SsherClient):
             return stdout.read().decode('utf-8')
         except UnicodeDecodeError as e:
             self.stdio.warn("[remote] Execute Shell command UnicodeDecodeError, command=[{0}]  Exception = [{1}]".format(cmd, e))
-            stdin, stdout, stderr = self._ssh_fd.exec_command(cmd)
             if stderr:
                 return str(stderr)
             return str(stdout)

--- a/common/ssh_client/remote_client.py
+++ b/common/ssh_client/remote_client.py
@@ -99,7 +99,9 @@ class RemoteClient(SsherClient):
             self.stdio.warn("[remote] Execute Shell command UnicodeDecodeError, command=[{0}]  Exception = [{1}]".format(cmd, e))
             if stderr:
                 return str(stderr)
-            return str(stdout)
+            if stdout:
+                return str(stdout)
+            return ""
         except SSHException as e:
             raise OBDIAGShellCmdException("Execute Shell command on server {0} failed, " "command=[{1}], exception:{2}".format(self.host_ip, cmd, e))
 

--- a/common/ssh_client/remote_client.py
+++ b/common/ssh_client/remote_client.py
@@ -65,7 +65,7 @@ class RemoteClient(SsherClient):
                 self._ssh_fd.load_system_host_keys()
                 self._ssh_fd.connect(hostname=self.host_ip, username=self.username, key_filename=self.key_file, port=self.ssh_port, disabled_algorithms=self._disabled_rsa_algorithms)
             except AuthenticationException:
-                self.password = input("Authentication failed, Input {0}@{1} password:\n".format(self.username, self.ssh_port))
+                self.password = input("Authentication failed, Input {0}@{1} password:\n".format(self.username, self.host_ip))
                 self.need_password = True
                 self._ssh_fd.connect(hostname=self.host_ip, username=self.username, password=self.password, port=self.ssh_port, disabled_algorithms=self._disabled_rsa_algorithms)
             except Exception as e:
@@ -94,6 +94,12 @@ class RemoteClient(SsherClient):
             if len(err_text):
                 return err_text.decode('utf-8')
             return stdout.read().decode('utf-8')
+        except UnicodeDecodeError as e:
+            self.stdio.warn("[remote] Execute Shell command UnicodeDecodeError, command=[{0}]  Exception = [{1}]".format(cmd, e))
+            stdin, stdout, stderr = self._ssh_fd.exec_command(cmd)
+            if stderr:
+                return str(stderr)
+            return str(stdout)
         except SSHException as e:
             raise OBDIAGShellCmdException("Execute Shell command on server {0} failed, " "command=[{1}], exception:{2}".format(self.host_ip, cmd, e))
 


### PR DESCRIPTION
fix: When the reply message cannot be encoded by UTF-8, return the original message directly