### PR TITLE
Revert "Bump cryptography from 42.0.4 to 43.0.1"

### DIFF
--- a/requirements3.txt
+++ b/requirements3.txt
@@ -3,7 +3,7 @@ certifi==2024.7.4
 cffi==1.15.0
 charset-normalizer==2.0.12
 constant==0.0.4
-cryptography==43.0.1
+cryptography==42.0.4
 idna==3.7
 Jinja2==3.1.4
 MarkupSafe==2.0.1


### PR DESCRIPTION
Reverts oceanbase/obdiag#417