### PR TITLE
add start check for obdiag work directory

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - master
-      - feature-start_check
 
 env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      - feature-start_check
 
 env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true

--- a/diag_cmd.py
+++ b/diag_cmd.py
@@ -194,10 +194,11 @@ class BaseCommand(object):
         return self.parser.format_help(OptionHelpFormatter())
 
     def start_check(self):
-        current_path = os.path.abspath(__file__)
-        print("---------------------------------->>")
-        print(current_path)
-        print("---------------------------------->>")
+        current_work_path = os.getcwd()
+        home_path = os.path.expanduser("~")
+        if current_work_path.startswith(home_path + "/.obdiag"):
+            ROOT_IO.error("Cannot be executed in the obdiag working directory!")
+            ROOT_IO.exit(1)
 
 
 class ObdiagOriginCommand(BaseCommand):

--- a/diag_cmd.py
+++ b/diag_cmd.py
@@ -384,6 +384,7 @@ class MajorCommand(BaseCommand):
         return super(MajorCommand, self)._mk_usage()
 
     def do_command(self):
+        self.start_check()
         if not self.is_init:
             ROOT_IO.error('%s command not init' % self.prev_cmd)
             raise SystemExit('command not init')
@@ -1163,7 +1164,6 @@ class ObdiagRCACommand(MajorCommand):
 class MainCommand(MajorCommand):
 
     def __init__(self):
-        self.start_check()
         super(MainCommand, self).__init__('obdiag', '')
         self.register_command(DisplayTraceCommand())
         self.register_command(ObdiagGatherCommand())

--- a/diag_cmd.py
+++ b/diag_cmd.py
@@ -16,7 +16,7 @@
 """
 
 from __future__ import absolute_import, division, print_function
-from common.tool import Util
+from common.tool import Util, StringUtils
 
 import os
 import sys
@@ -413,16 +413,13 @@ class MajorCommand(BaseCommand):
     def start_check(self):
         current_work_path = os.getcwd()
         home_path = os.path.expanduser("~")
-        version_main_num = 0
-        if len(OBDIAG_VERSION) > 0:
-            if OBDIAG_VERSION[0].isdigit():
-                version_main_num = int(OBDIAG_VERSION[0])
-        if current_work_path.startswith(home_path + "/.obdiag"):
-            if version_main_num >= 3:
-                ROOT_IO.error("Cannot be executed in the obdiag working directory!")
-                ROOT_IO.exit(1)
-            else:
-                ROOT_IO.warn("Currently executing in obdiag home directory!")
+        if '.' in OBDIAG_VERSION:
+            if current_work_path.startswith(home_path + "/.obdiag"):
+                if StringUtils.compare_versions_lower(OBDIAG_VERSION, "3.0.0"):
+                    ROOT_IO.warn("Currently executing in obdiag home directory!")
+                else:
+                    ROOT_IO.error("Cannot be executed in the obdiag working directory!")
+                    ROOT_IO.exit(1)
 
 
 class ObdiagGatherAllCommand(ObdiagOriginCommand):

--- a/diag_cmd.py
+++ b/diag_cmd.py
@@ -105,6 +105,7 @@ class AllowUndefinedOptionParser(OptionParser):
 class BaseCommand(object):
 
     def __init__(self, name, summary):
+        self.start_check()
         self.name = name
         self.summary = summary
         self.args = []
@@ -191,6 +192,12 @@ class BaseCommand(object):
 
     def _mk_usage(self):
         return self.parser.format_help(OptionHelpFormatter())
+
+    def start_check(self):
+        current_path = os.path.abspath(__file__)
+        print("---------------------------------->>")
+        print(current_path)
+        print("---------------------------------->>")
 
 
 class ObdiagOriginCommand(BaseCommand):


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->
add start check for obdiag work directory

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
When executing commands in the obdiag working directory, the program will exit abnormally. close #441 


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
