### PR TITLE
The default result path for obdiag rca has been changed to ./obdiag_rca

### DIFF
--- a/common/constant.py
+++ b/common/constant.py
@@ -74,7 +74,7 @@ const.OBDIAG_GATHER_DEFAULT_CONFIG = {"gather": {"cases_base_path": "~/.obdiag/g
 
 const.OBDIAG_RCA_DEFAULT_CONFIG = {
     "rca": {
-        "result_path": "./rca/",
+        "result_path": "./obdiag_rca/",
     }
 }
 const.OBDIAG_TELEMETRY_FILE_NAME = os.path.expanduser("~/.obdiag/.obdiag_telemetry.txt")

--- a/conf/inner_config.yml
+++ b/conf/inner_config.yml
@@ -27,4 +27,4 @@ gather:
   scenes_base_path: "~/.obdiag/gather/tasks"
   redact_processing_num: 3
 rca:
-  result_path: "./rca/"
+  result_path: "./obdiag_rca/"

--- a/config.py
+++ b/config.py
@@ -92,7 +92,7 @@ DEFAULT_INNER_CONFIG = {
     },
     'gather': {'scenes_base_path': '~/.obdiag/gather/tasks', 'redact_processing_num': 3},
     'rca': {
-        'result_path': './rca/',
+        'result_path': './obdiag_rca/',
     },
 }
 

--- a/diag_cmd.py
+++ b/diag_cmd.py
@@ -986,7 +986,7 @@ class ObdiagRCARunCommand(ObdiagOriginCommand):
     def __init__(self):
         super(ObdiagRCARunCommand, self).__init__('run', 'root cause analysis')
         self.parser.add_option('--scene', type='string', help="rca scene name. The argument is required.")
-        self.parser.add_option('--store_dir', type='string', help='the dir to store rca result, current dir by default.', default='./rca/')
+        self.parser.add_option('--store_dir', type='string', help='the dir to store rca result, current dir by default.', default='./obdiag_rca/')
         self.parser.add_option('--input_parameters', action='callback', type='string', callback=self._env_scene, help='input parameters of scene')
         self.parser.add_option('--env', action='callback', type='string', callback=self._env_scene, help='env of scene')
         self.parser.add_option('-c', type='string', help='obdiag custom config', default=os.path.expanduser('~/.obdiag/config.yml'))

--- a/docs/rca.md
+++ b/docs/rca.md
@@ -26,5 +26,5 @@ scene_name是需要执行的根因分析场景的名称,可以通过obdiag rca l
 rca功能所关联的配置项在"rca"下，基本上的参数均无需变更或更改频率较低
 ```yaml script
 rca:
-  result_path: "./rca/" # rca报告保存的地址
+  result_path: "./obdiag_rca/" # rca报告保存的地址
 ```

--- a/handler/rca/rca_handler.py
+++ b/handler/rca/rca_handler.py
@@ -78,7 +78,7 @@ class RCAHandler:
         # build report
         store_dir = Util.get_option(self.options, "store_dir")
         if store_dir is None:
-            store_dir = "./rca/"
+            store_dir = "./obdiag_rca/"
         self.stdio.verbose("RCAHandler.init store dir: {0}".format(store_dir))
         report = Result(self.context)
         report.set_save_path(store_dir)
@@ -125,7 +125,7 @@ class RCAHandler:
         self.tasks = None
         self.context.set_variable("input_parameters", Util.get_option(self.options, "input_parameters"))
         self.context.set_variable("env", Util.get_option(self.options, "input_parameters"))
-        self.store_dir = Util.get_option(self.options, "store_dir", "./rca/")
+        self.store_dir = Util.get_option(self.options, "store_dir", "./obdiag_rca/")
         self.context.set_variable("store_dir", self.store_dir)
         self.stdio.verbose(
             "RCAHandler init.cluster:{0}, init.nodes:{1}, init.obproxy_nodes:{2}, init.store_dir:{3}".format(


### PR DESCRIPTION
The default result path for obdiag rca has been changed to ./obdiag_rca

close #466 