### PR TITLE
增加临时打包脚本

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN rm -rf /etc/yum.repos.d/* \
 && bash Miniconda3-latest-Linux-x86_64.sh -p /opt/miniconda -b \
 && rm -rf Miniconda3-latest-Linux-x86_64.sh \
 && conda create -n obdiag -y python=3.8 \
-&& source /opt/miniconda/bin/activate obdiag
+&& source /opt/miniconda/bin/activate obdiag \
+&& python3 -m pip install --upgrade pip wheel
 
 COPY ./requirements3.txt /workspaces/obdiag/requirements3.txt
 RUN /opt/miniconda/envs/obdiag/bin/pip install -r /workspaces/obdiag/requirements3.txt -i https://pypi.tuna.tsinghua.edu.cn/simple

--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# 开始打包
+export RELEASE=`date +%Y%m%d%H%M`
+sed -i 's/pip install -r requirements3.txt/curl https:\/\/bootstrap.pypa.io\/get-pip.py -o get-pip.py\n\
+python3 get-pip.py\n\
+pip3 install -r requirements3.txt/' ./rpm/oceanbase-diagnostic-tool.spec
+cat ./rpm/oceanbase-diagnostic-tool.spec
+rpmbuild -bb ./rpm/oceanbase-diagnostic-tool.spec
+# 展示对应的包路径
+find / -name oceanbase-diagnostic-tool-*.rpm 

--- a/build_rpm.sh
+++ b/build_rpm.sh
@@ -6,6 +6,7 @@ sed -i 's/pip install -r requirements3.txt/curl https:\/\/bootstrap.pypa.io\/get
 python3 get-pip.py\n\
 pip3 install -r requirements3.txt/' ./rpm/oceanbase-diagnostic-tool.spec
 cat ./rpm/oceanbase-diagnostic-tool.spec
+yum install rpm-build -y
 rpmbuild -bb ./rpm/oceanbase-diagnostic-tool.spec
 # 展示对应的包路径
 find / -name oceanbase-diagnostic-tool-*.rpm 


### PR DESCRIPTION
近期github变更了workflow上的node版本，导致原打包流水线失败。为了满足大家打临时包的需求，开发者手册中临时增加本地基于docker的打包策略。同时新增了打包脚本 **./build_rpm.sh** 
该脚本基于**DEVContain**开发，开发者使用的时候，需要进入到开发容器后，在根目录执行`sh build_rpm.sh`，打包完后默认的包路径在 **/root/rpmbuild/RPMS/x86_64**