### PR TITLE
Fix the creation of the configuration file 'inner config.yml' as a directory

### DIFF
--- a/src/common/config.py
+++ b/src/common/config.py
@@ -29,12 +29,13 @@ if getattr(sys, 'frozen', False):
     absPath = os.path.dirname(os.path.abspath(sys.executable))
 else:
     absPath = os.path.dirname(os.path.abspath(__file__))
-inner_config_release_path = os.path.join(absPath, "conf/inner_config.yml")
-inner_config_dev_path = os.path.join(absPath, "../../conf/inner_config.yml")
+inner_config_release_path = os.path.join(absPath, "conf/")
+inner_config_dev_path = os.path.join(absPath, "../../conf/")
 if os.path.exists(inner_config_release_path):
-    INNER_CONFIG_FILE = inner_config_release_path
+    INNER_CONFIG_PATH = inner_config_release_path
 else:
-    INNER_CONFIG_FILE = inner_config_dev_path
+    INNER_CONFIG_PATH = inner_config_dev_path
+INNER_CONFIG_FILE = INNER_CONFIG_PATH + "inner_config.yml"
 
 DEFAULT_CONFIG_DATA = '''
 obcluster:
@@ -121,20 +122,20 @@ class Manager(SafeStdio):
 
     def load_config(self):
         try:
-            with open(self.path, 'r') as file:
+            with open(INNER_CONFIG_FILE, 'r') as file:
                 return yaml.safe_load(file)
         except FileNotFoundError:
-            self.stdio.exception(f"Configuration file '{self.path}' not found.")
+            self.stdio.exception(f"Configuration file '{INNER_CONFIG_FILE}' not found.")
         except yaml.YAMLError as exc:
             self.stdio.exception(f"Error parsing YAML file: {exc}")
 
     def load_config_with_defaults(self, defaults_dict):
         default_config = defaultdict(lambda: None, defaults_dict)
         try:
-            with open(self.path, 'r') as stream:
+            with open(INNER_CONFIG_FILE, 'r') as stream:
                 loaded_config = yaml.safe_load(stream)
         except FileNotFoundError:
-            self.stdio.exception(f"Configuration file '{self.path}' not found.")
+            self.stdio.exception(f"Configuration file '{INNER_CONFIG_FILE}' not found.")
             return default_config
         except yaml.YAMLError as exc:
             self.stdio.exception(f"Error parsing YAML file: {exc}")
@@ -312,7 +313,7 @@ class InnerConfigManager(Manager):
     def __init__(self, stdio=None, inner_config_change_map=None):
         if inner_config_change_map is None:
             inner_config_change_map = {}
-        inner_config_abs_path = os.path.abspath(INNER_CONFIG_FILE)
+        inner_config_abs_path = os.path.abspath(INNER_CONFIG_PATH)
         super().__init__(inner_config_abs_path, stdio=stdio)
         self.config = self.load_config_with_defaults(DEFAULT_INNER_CONFIG)
         if inner_config_change_map != {}:

--- a/src/common/tool.py
+++ b/src/common/tool.py
@@ -351,6 +351,8 @@ class DirectoryUtil(object):
     def mkdir(path, mode=0o755, stdio=None):
         stdio and getattr(stdio, 'verbose', print)('mkdir %s' % path)
         try:
+            if os.path.exists(path):
+                return True
             os.makedirs(path, mode=mode)
             return True
         except OSError as e:


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->
fix the creation of the configuration file 'inner config.yml' as a directory.

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
![image](https://github.com/user-attachments/assets/94a3978b-5bfd-496e-9423-81135244b971)
When the `config/inner_config.yml` was not created, the `config/inner_config.yml` file was created as a directory.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
