### PR TITLE
fixed: init.sh cp: overwrite

### DIFF
--- a/rpm/init.sh
+++ b/rpm/init.sh
@@ -35,7 +35,7 @@ mkdir -p ${OBDIAG_HOME}/display
 # Clean rca old *scene.py files
 find ${OBDIAG_HOME}/rca -maxdepth 1 -name "*_scene.py" -type f -exec rm -f {} + 2>/dev/null
 
-cp -rf ${WORK_DIR}/plugins/*  ${OBDIAG_HOME}/
+\cp -rf ${WORK_DIR}/plugins/*  ${OBDIAG_HOME}/
 
 bashrc_file=~/.bashrc
 if [ -e "$bashrc_file" ]; then


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

1. cp 命令的别名干扰

- 部分 Linux 系统（如 Ubuntu）默认将 cp 定义为别名 cp -i，强制交互式覆盖确认。
- 当使用 source 执行脚本时，脚本中的 cp 会继承当前 Shell 的别名 cp -i，导致覆盖提示；而 sh 启动的子 Shell 可能未继承该别名，直接调用原生命令 cp（不带 -i 参数），因此不会提示。

2. 系统配置差异

某些操作系统默认启用 cp -i 别名，另一些则未启用。所以这个问题仅出现在部分系统中

![image](https://github.com/user-attachments/assets/a39a3ec3-94b3-4065-bceb-53cfcb753900)



## Solution Description
<!-- Please clearly and concisely describe your solution. -->

通过 \cp 忽略别名
