### PR TITLE
fixed bug on [ index_ddl_error.py, network_write_cond_wakeup.py, og_easy_slow.py]

### DIFF
--- a/plugins/check/tasks/observer/network/log_easy_slow.py
+++ b/plugins/check/tasks/observer/network/log_easy_slow.py
@@ -39,7 +39,7 @@ class LogEasySlowTask(TaskBase):
 
                 # Check observer.log for "EASY SLOW" occurrences
                 log_file_path = "{0}/log/observer.log".format(home_path)
-                check_cmd = "grep -c 'EASY SLOW' {0} 2>/dev/null || echo '0'".format(log_file_path)
+                check_cmd = "grep -c 'EASY SLOW' {0} 2>/dev/null".format(log_file_path)
 
                 result = ssh_client.exec_cmd(check_cmd).strip()
                 self.stdio.verbose("Found {0} 'EASY SLOW' occurrences in {1} on {2}".format(result, log_file_path, ssh_client.get_name()))

--- a/plugins/check/tasks/observer/network/network_write_cond_wakeup.py
+++ b/plugins/check/tasks/observer/network/network_write_cond_wakeup.py
@@ -39,7 +39,7 @@ class NetworkWriteCondWakeupTask(TaskBase):
 
                 # Check observer.log for "write cond wakeup" occurrences
                 log_file_path = "{0}/log/observer.log".format(home_path)
-                check_cmd = "grep -c 'write cond wakeup' {0} 2>/dev/null || echo '0'".format(log_file_path)
+                check_cmd = "grep -c 'write cond wakeup' {0} 2>/dev/null".format(log_file_path)
 
                 result = ssh_client.exec_cmd(check_cmd).strip()
                 self.stdio.verbose("Found {0} 'write cond wakeup' occurrences in {1} on {2}".format(result, log_file_path, ssh_client.get_name()))

--- a/plugins/rca/index_ddl_error.py
+++ b/plugins/rca/index_ddl_error.py
@@ -128,7 +128,7 @@ class IndexDDLErrorScene(RcaScene):
             )
             event_data = self.ob_connector.execute_sql_return_cursor_dictionary(sql).fetchall()
             self.verbose("event_data is{0}".format(event_data))
-            if event_data is None or len(event_data) == 0 :
+            if event_data is None or len(event_data) == 0:
                 record.add_record("gather rootservice.log  by {0}".format(self.trace_id))
                 # rs
                 self.verbose("event_data is None")

--- a/plugins/rca/index_ddl_error.py
+++ b/plugins/rca/index_ddl_error.py
@@ -128,7 +128,7 @@ class IndexDDLErrorScene(RcaScene):
             )
             event_data = self.ob_connector.execute_sql_return_cursor_dictionary(sql).fetchall()
             self.verbose("event_data is{0}".format(event_data))
-            if event_data is None:
+            if event_data is None or len(event_data) == 0 :
                 record.add_record("gather rootservice.log  by {0}".format(self.trace_id))
                 # rs
                 self.verbose("event_data is None")


### PR DESCRIPTION
on index_ddl_error.py

There is a bug. 

If event_data is not None but empty

on [network_write_cond_wakeup.py  log_easy_slow.py]

There is a bug. 

If 'write cond wakeup' is not found in the log file, 'grep' fails and then 'echo' is triggered, the result will be '0\n0'.

If 'EASY SLOW' is not found in the log file, 'grep' fails and then 'echo' is triggered, the result will be '0\n0'.

Then, 'easy_slow_count = int(result)' failed

