### PR TITLE
Failed to obtain the $LANG variable of the observer node 

### DIFF
--- a/plugins/check/tasks/observer/network/log_easy_slow.py
+++ b/plugins/check/tasks/observer/network/log_easy_slow.py
@@ -39,7 +39,7 @@ class LogEasySlowTask(TaskBase):
 
                 # Check observer.log for "EASY SLOW" occurrences
                 log_file_path = "{0}/log/observer.log".format(home_path)
-                check_cmd = "grep -c 'EASY SLOW' {0} 2>/dev/null || echo '0'".format(log_file_path)
+                check_cmd = "grep -c 'EASY SLOW' {0} 2>/dev/null".format(log_file_path)
 
                 result = ssh_client.exec_cmd(check_cmd).strip()
                 self.stdio.verbose("Found {0} 'EASY SLOW' occurrences in {1} on {2}".format(result, log_file_path, ssh_client.get_name()))

--- a/plugins/check/tasks/observer/network/network_write_cond_wakeup.py
+++ b/plugins/check/tasks/observer/network/network_write_cond_wakeup.py
@@ -39,7 +39,7 @@ class NetworkWriteCondWakeupTask(TaskBase):
 
                 # Check observer.log for "write cond wakeup" occurrences
                 log_file_path = "{0}/log/observer.log".format(home_path)
-                check_cmd = "grep -c 'write cond wakeup' {0} 2>/dev/null || echo '0'".format(log_file_path)
+                check_cmd = "grep -c 'write cond wakeup' {0} 2>/dev/null".format(log_file_path)
 
                 result = ssh_client.exec_cmd(check_cmd).strip()
                 self.stdio.verbose("Found {0} 'write cond wakeup' occurrences in {1} on {2}".format(result, log_file_path, ssh_client.get_name()))

--- a/plugins/check/tasks/observer/system/check_system_language.py
+++ b/plugins/check/tasks/observer/system/check_system_language.py
@@ -33,7 +33,8 @@ class CheckSystemLanguage(TaskBase):
                 continue
             try:
                 # check $LANG is en_US.UTF-8
-                cmd = f"echo $LANG | grep 'en_US.UTF-8'"
+                # cmd = f"echo $LANG | grep 'en_US.UTF-8'"
+                cmd = f"""bash -l -c "echo \$LANG" | grep -iP 'en_US.utf(-|)8'"""
                 self.stdio.verbose(f"Executing on {ip}: {cmd}")
                 system_language_check = ssher.exec_cmd(cmd).strip()
                 if not system_language_check:

--- a/plugins/rca/ddl_failure.py
+++ b/plugins/rca/ddl_failure.py
@@ -94,7 +94,7 @@ class DDLFailureScene(RcaScene):
         sql_result = self.ob_connector.execute_sql_return_cursor_dictionary(sql).fetchall()
         self.verbose("query sql: {0}\nsql result: {1}".format(sql, sql_result))
         if len(sql_result) <= 0:
-            raise RCAInitException("table not found, query sql: {0}".format(sql))
+            raise RCAInitException("Record not found, query sql: {0}".format(sql))
         else:
             if sql_result[0]["index_type"] > 0 or sql_result[0]["data_table_id"] == 0:
                 pass

--- a/plugins/rca/index_ddl_error.py
+++ b/plugins/rca/index_ddl_error.py
@@ -128,7 +128,7 @@ class IndexDDLErrorScene(RcaScene):
             )
             event_data = self.ob_connector.execute_sql_return_cursor_dictionary(sql).fetchall()
             self.verbose("event_data is{0}".format(event_data))
-            if event_data is None or len(event_data) == 0 :
+            if event_data is None or len(event_data) == 0:
                 record.add_record("gather rootservice.log  by {0}".format(self.trace_id))
                 # rs
                 self.verbose("event_data is None")

--- a/plugins/rca/index_ddl_error.py
+++ b/plugins/rca/index_ddl_error.py
@@ -128,7 +128,7 @@ class IndexDDLErrorScene(RcaScene):
             )
             event_data = self.ob_connector.execute_sql_return_cursor_dictionary(sql).fetchall()
             self.verbose("event_data is{0}".format(event_data))
-            if event_data is None:
+            if event_data is None or len(event_data) == 0 :
                 record.add_record("gather rootservice.log  by {0}".format(self.trace_id))
                 # rs
                 self.verbose("event_data is None")

--- a/src/common/diag_cmd.py
+++ b/src/common/diag_cmd.py
@@ -868,6 +868,7 @@ class ObdiagAnalyzeQueueCommand(ObdiagOriginCommand):
         self.parser.add_option('--since', type='string', help="Specify time range that from 'n' [d]ays, 'n' [h]ours or 'n' [m]inutes. before to now. format: <n> <m|h|d>. example: 1h.", default='30m')
         self.parser.add_option('--tenant', type='string', help="Specify tenantname ")
         self.parser.add_option('--queue', type='int', help="quene size ", default=50)
+        self.parser.add_option('--config', action="append", type="string", help='config options Format: --config key=value')
 
     def init(self, cmd, args):
         super(ObdiagAnalyzeQueueCommand, self).init(cmd, args)


### PR DESCRIPTION
Here are three issues:
1.Directly using $LANG retrieves the variable from the local machine. To obtain the variable value from the SSH target machine, the variable must be escaped or enclosed in single quotes.  [For example : echo '${LANG}' or echo \${LANG}]
2.On some systems, ssh may not load environment variables, causing the retrieved variable value to differ from the one obtained when logging directly into the machine (this issue has been observed on Debian 9).
3.Some systems return uppercase values while others return lowercase, leading to inconsistent formats. The solution needs to accommodate multiple formats.[For example : Rocky Linux release 9.5 (Blue Onyx)]