### PR TITLE
Fix the bug where line breaks are lost when copying sql_plan_monitor_report.html SQL text

### DIFF
--- a/src/handler/meta/html_meta.py
+++ b/src/handler/meta/html_meta.py
@@ -186,6 +186,7 @@ html_dict.set_value(
       $('td').each(function() {
         var $td = $(this);
         var text = $td.text().trim();
+        var htmlContent = $td.html().trim();
         
         // 检查是否包含SQL语句（简单的判断条件）
         if (text.length > 50 && (text.toLowerCase().includes('select') || text.toLowerCase().includes('insert') || text.toLowerCase().includes('update') || text.toLowerCase().includes('delete'))) {
@@ -209,9 +210,15 @@ html_dict.set_value(
             if ($text.hasClass('expanded')) {
               $text.removeClass('expanded');
               $btn.text('展开');
+              $text.text(text);
             } else {
               $text.addClass('expanded');
               $btn.text('收缩');
+              if (htmlContent.includes('<br>')) {
+                $text.html(htmlContent);
+              } else {
+                $text.text(text);
+              }
             }
           });
           
@@ -222,7 +229,11 @@ html_dict.set_value(
             
             // 创建临时textarea来复制文本
             var textarea = document.createElement('textarea');
-            textarea.value = text;
+            if (htmlContent.includes('<br>')) {
+              textarea.value = htmlContent.replace(/<br\s*\/?>/gi, '\\n').replace(/&nbsp;/g, ' ');
+            } else {
+              textarea.value = text;
+            }
             document.body.appendChild(textarea);
             textarea.select();
             
@@ -509,6 +520,7 @@ html_dict.set_value(
       $('td').each(function() {
         var $td = $(this);
         var text = $td.text().trim();
+        var htmlContent = $td.html().trim();
         
         // 检查是否包含SQL语句（简单的判断条件）
         if (text.length > 50 && (text.toLowerCase().includes('select') || text.toLowerCase().includes('insert') || text.toLowerCase().includes('update') || text.toLowerCase().includes('delete'))) {
@@ -532,9 +544,15 @@ html_dict.set_value(
             if ($text.hasClass('expanded')) {
               $text.removeClass('expanded');
               $btn.text('展开');
+              $text.text(text);
             } else {
               $text.addClass('expanded');
               $btn.text('收缩');
+              if (htmlContent.includes('<br>')) {
+                $text.html(htmlContent);
+              } else {
+                $text.text(text);
+              }
             }
           });
           
@@ -545,7 +563,11 @@ html_dict.set_value(
             
             // 创建临时textarea来复制文本
             var textarea = document.createElement('textarea');
-            textarea.value = text;
+            if (htmlContent.includes('<br>')) {
+              textarea.value = htmlContent.replace(/<br\s*\/?>/gi, '\\n').replace(/&nbsp;/g, ' ');
+            } else {
+              textarea.value = text;
+            }
             document.body.appendChild(textarea);
             textarea.select();
             


### PR DESCRIPTION

Fix the bug where line breaks are lost when copying sql_plan_monitor_report.html SQL text



```sql
create table game (round int primary key, team varchar(10), score int)
    partition by hash(round) partitions 3;

insert into game values (1, "CN", 4), (2, "CN", 5), (3, "JP", 3);
insert into game values (4, "CN", 4), (5, "US", 4), (6, "JP", 4);
```

```sql
select /*+ parallel(3) */ 
team, 
sum(score)
total
from
game
group
by
team;

```

```sql
SELECT last_trace_id();
```

```bash
obdiag gather plan_monitor --env "{db_connect='-hxxx -Pxxxx -uxxxx -p**** -Dtest'}" --trace_id=xxxx

```

修复前：
复制出来的结果, 因为换行符导致复制的结果中丢失了换行符，文本连空格都没有，SQL语句已经变得无法执行。
```sql
select /*+ parallel(3) */ team, sum(score)totalfromgamegroupbyteam
```

修复后，复制出来的结果，不破坏原有的SQL语句
```sql
select /*+ parallel(3) */ 
team, 
sum(score)
total
from
game
group
by
team

```

<img width="1796" height="794" alt="image" src="https://github.com/user-attachments/assets/8ecc9651-4e7a-4454-a0da-9c107f8fc7ac" />
