### PR TITLE
Update system language check command

### DIFF
--- a/plugins/check/tasks/observer/system/check_system_language.py
+++ b/plugins/check/tasks/observer/system/check_system_language.py
@@ -34,7 +34,8 @@ class CheckSystemLanguage(TaskBase):
             try:
                 # check $LANG is en_US.UTF-8
                 # cmd = f"echo $LANG | grep 'en_US.UTF-8'"
-                cmd = f"""bash -l -c "echo \$LANG" | grep -iP 'en_US.utf(-|)8'"""
+                # cmd = f"""bash -l -c "echo \$LANG" | grep -iP 'en_US.utf(-|)8'"""
+                cmd = f"""bash -l -c 'locale|grep -P "LANG=en(_|-)US.UTF(_|-|)8"'"""
                 self.stdio.verbose(f"Executing on {ip}: {cmd}")
                 system_language_check = ssher.exec_cmd(cmd).strip()
                 if not system_language_check:


### PR DESCRIPTION
fix the bug.

The value of a variable obtained non-interactively by ssh is inconsistent with the value obtained by logging into the machine.

The results of commands like the following two may be different.

```
# ssh ip "bash -l -c \"echo \$LANG\" | grep -iP 'en_US.utf(-|)8'"
```

```
# ssh ip
# bash -l -c "echo $LANG" | grep -iP 'en_US.utf(-|)8'
```

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->



## Solution Description
<!-- Please clearly and concisely describe your solution. -->
