### PR TITLE
fix(backup): 修复环境变量格式问题 || fix(backup): Fix environment variable format problem

### DIFF
--- a/plugins/gather/tasks/observer/backup.yaml
+++ b/plugins/gather/tasks/observer/backup.yaml
@@ -1,6 +1,6 @@
 info_en: "[backup problem]"
 info_cn: "[数据备份问题]"
-command: obdiag gather scene run --scene=observer.backup --env "{tenant_id=xxx}"
+command: obdiag gather scene run --scene=observer.backup --env tenant_id=xxx
 task:
   - version: "[2.0.0.0, 3.9.9.9]"
     steps:

--- a/plugins/gather/tasks/observer/backup_clean.yaml
+++ b/plugins/gather/tasks/observer/backup_clean.yaml
@@ -1,6 +1,6 @@
 info_en: "[backup clean]"
 info_cn: "[备份清理问题]"
-command: obdiag gather scene run --scene=observer.backup_clean --env "{tenant_id=xxx}"
+command: obdiag gather scene run --scene=observer.backup_clean --env tenant_id=xxx
 task:
   - version: "[2.0.0.0, 3.9.9.9]"
     steps:


### PR DESCRIPTION
- 移除多余的引号和大括号
- 统一备份和清理任务的参数格式


<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
- Remove redundant quotes and braces
- Unified parameter format for backup and cleanup tasks
