### PR TITLE
refactor(rca): Unify file naming conventions

### DIFF
--- a/plugins/rca/clog_disk_full.py
+++ b/plugins/rca/clog_disk_full.py
@@ -12,7 +12,7 @@
 
 """
 @time: 2024/05/20
-@file: clog_disk_full_scene.py
+@file: clog_disk_full.py
 @desc:
 """
 import datetime

--- a/plugins/rca/ddl_disk_full.py
+++ b/plugins/rca/ddl_disk_full.py
@@ -12,7 +12,7 @@
 
 """
 @time: 2024/04/01
-@file: ddl_disk_full_scene.py
+@file: ddl_disk_full.py
 @desc:
 """
 

--- a/plugins/rca/ddl_failure.py
+++ b/plugins/rca/ddl_failure.py
@@ -12,7 +12,7 @@
 
 """
 @time: 2024/06/12
-@file: ddl_failure_scene.py
+@file: ddl_failure.py
 @desc:
 """
 import os

--- a/plugins/rca/index_ddl_error.py
+++ b/plugins/rca/index_ddl_error.py
@@ -12,7 +12,7 @@
 
 """
 @time: 2024/06/04
-@file: index_ddl_error_scene.py
+@file: index_ddl_error.py
 @desc:
 """
 

--- a/plugins/rca/lock_conflict.py
+++ b/plugins/rca/lock_conflict.py
@@ -12,7 +12,7 @@
 
 """
 @time: 2024/07/29
-@file: lock_conflict_scene.py
+@file: lock_conflict.py
 @desc: Root cause analysis for lock conflict issues.
        Supports:
        - GV$OB_LOCKS based analysis (4.2+)

--- a/plugins/rca/log_error.py
+++ b/plugins/rca/log_error.py
@@ -12,7 +12,7 @@
 
 """
 @time: 2024/04/16
-@file: log_error_scene.py
+@file: log_error.py
 @desc:
 """
 import os

--- a/plugins/rca/major_hold.py
+++ b/plugins/rca/major_hold.py
@@ -12,7 +12,7 @@
 
 """
 @time: 2024/1/2
-@file: major_hold_scene.py
+@file: major_hold.py
 @desc: RCA scene for diagnosing major compaction hold issues
        Reference: https://open.oceanbase.com/blog/14847857236
 """

--- a/plugins/rca/transaction_disconnection.py
+++ b/plugins/rca/transaction_disconnection.py
@@ -12,7 +12,7 @@
 
 """
 @time: 2024/05/28
-@file: transaction_disconnection_scene.py
+@file: transaction_disconnection.py
 @desc: Root cause analysis for session disconnection during transaction.
        Common causes: ob_trx_idle_timeout, ob_trx_timeout exceeded
        Reference: [4.0] 事务问题通用排查手册

--- a/plugins/rca/transaction_execute_timeout.py
+++ b/plugins/rca/transaction_execute_timeout.py
@@ -12,7 +12,7 @@
 
 """
 @time: 2024/05/20
-@file: transaction_execute_timeout_scene.py
+@file: transaction_execute_timeout.py
 @desc: Root cause analysis for transaction/statement timeout errors.
        Error code: 4012 (internal: -6212 statement timeout, -6210 transaction timeout)
        Reference: [4.0] 事务问题通用排查手册

--- a/plugins/rca/transaction_not_ending.py
+++ b/plugins/rca/transaction_not_ending.py
@@ -12,7 +12,7 @@
 
 """
 @time: 2024/05/20
-@file: transaction_not_ending_scene.py
+@file: transaction_not_ending.py
 @desc: Root cause analysis for transaction not ending issues.
        Reference: [4.0] 事务问题通用排查手册
 """

--- a/plugins/rca/transaction_other_error.py
+++ b/plugins/rca/transaction_other_error.py
@@ -12,7 +12,7 @@
 
 """
 @time: 2024/05/20
-@file: transaction_other_error_scene.py
+@file: transaction_other_error.py
 @desc: Root cause analysis for transaction other errors.
        Handles error codes: -4013, -4030, -4121, -4122, -4124, -4019
        Reference: [4.0] 事务问题通用排查手册

--- a/plugins/rca/transaction_rollback.py
+++ b/plugins/rca/transaction_rollback.py
@@ -12,7 +12,7 @@
 
 """
 @time: 2024/05/20
-@file: transaction_rollback_scene.py
+@file: transaction_rollback.py
 @desc: Root cause analysis for transaction rollback errors.
        Error codes: 6002 (internal: -6224, -6223, -6211, -6213)
        - -6224: transaction need rollback

--- a/plugins/rca/transaction_wait_timeout.py
+++ b/plugins/rca/transaction_wait_timeout.py
@@ -12,7 +12,7 @@
 
 """
 @time: 2024/05/20
-@file: transaction_wait_timeout_scene.py
+@file: transaction_wait_timeout.py
 @desc: Root cause analysis for lock wait timeout.
        NOTE: This scene is now integrated into lock_conflict scene.
        Supports: "Shared lock conflict" (-6004) and "Lock wait timeout exceeded" (-6003)


### PR DESCRIPTION
- Remove the "_scene" suffix from the filenames
- Maintain the functionality unchanged, only modify the file name
