### PR TITLE
Feature: Add obdiag command line entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,3 +82,6 @@ macos = [
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["src*"]
+
+[project.scripts]
+obdiag = "src.main:main"


### PR DESCRIPTION
-Configure project script entry in pyproject.toml
-The main program can be directly called through the obdiag command
