### PR TITLE
Add SQL syntax validation tool

### DIFF
--- a/src/common/core.py
+++ b/src/common/core.py
@@ -655,6 +655,18 @@ class ObdiagHome(object):
             handler = IoPerformanceHandler(self.context)
             return handler.handle()
 
+    def tool_sql_syntax(self, opt):
+        config = self.config_manager
+        if not config:
+            self._call_stdio('error', 'No such custom config')
+            return ObdiagResult(ObdiagResult.INPUT_ERROR_CODE, error_data='No such custom config')
+        else:
+            self.set_context_skip_cluster_conn('tool_sql_syntax', 'tool_sql_syntax', config)
+            from src.handler.tools.sql_syntax_handler import SqlSyntaxHandler
+
+            handler = SqlSyntaxHandler(self.context)
+            return handler.handle()
+
     def config(self, opt):
         config = self.config_manager
         if not config:

--- a/src/common/diag_cmd.py
+++ b/src/common/diag_cmd.py
@@ -1353,6 +1353,27 @@ class ObdiagToolConfigCheckCommand(ObdiagOriginCommand):
         return obdiag.tool_config_check(self.opts)
 
 
+class ObdiagToolSqlSyntaxCommand(ObdiagOriginCommand):
+
+    def __init__(self):
+        super(ObdiagToolSqlSyntaxCommand, self).__init__(
+            'sql_syntax',
+            'obdiag tool sql_syntax. Validate SQL against a live OceanBase instance using EXPLAIN (no execution of the original statement)',
+        )
+        self.parser.add_option('--sql', type='string', help='SQL statement to validate (single statement only)')
+        self.parser.add_option('--env', action='append', type='string', help='Connection override: --env key=value (host, port, user, password/pwd, database/db)')
+        self.parser.add_option('-c', type='string', help='obdiag custom config', default=os.path.expanduser('~/.obdiag/config.yml'))
+        self.parser.add_option('--config', action='append', type='string', help='config options Format: --config key=value')
+
+    def init(self, cmd, args):
+        super(ObdiagToolSqlSyntaxCommand, self).init(cmd, args)
+        self.parser.set_usage('%s [options]' % self.prev_cmd)
+        return self
+
+    def _do_command(self, obdiag):
+        return obdiag.tool_sql_syntax(self.opts)
+
+
 class ObdiagGatherCommand(MajorCommand):
 
     def __init__(self):
@@ -1437,6 +1458,7 @@ class ToolCommand(MajorCommand):
         self.register_command(ObdiagToolCryptoConfigCommand())
         self.register_command(ObdiagToolIoPerformanceCommand())
         self.register_command(ObdiagToolConfigCheckCommand())
+        self.register_command(ObdiagToolSqlSyntaxCommand())
 
 
 class MainCommand(MajorCommand):

--- a/src/common/executor.py
+++ b/src/common/executor.py
@@ -38,6 +38,7 @@ OBDIAG_COMMANDS = {
     "rca_run": "obdiag rca run",
     "rca_list": "obdiag rca list",
     "tool_io_performance": "obdiag tool io_performance",
+    "tool_sql_syntax": "obdiag tool sql_syntax",
 }
 
 

--- a/src/handler/agent/mcp/server.py
+++ b/src/handler/agent/mcp/server.py
@@ -48,6 +48,7 @@ class MCPServer:
         "rca_run": "obdiag rca run",
         "rca_list": "obdiag rca list",
         "tool_io_performance": "obdiag tool io_performance",
+        "tool_sql_syntax": "obdiag tool sql_syntax",
     }
 
     def __init__(self, config_path: Optional[str] = None, stdio=None, context=None):
@@ -103,6 +104,22 @@ class MCPServer:
                 "name": "tool_io_performance",
                 "description": "Check disk IO performance using tsar",
                 "inputSchema": {"type": "object", "properties": {"disk": {"type": "string", "description": "Disk device name (e.g., sda, clog, data)"}, "date": {"type": "string", "description": "Date for historical data (format: YYYYMMDD)"}}},
+            },
+            {
+                "name": "tool_sql_syntax",
+                "description": "Validate SQL syntax/semantics on OceanBase using EXPLAIN without executing the statement",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "sql": {"type": "string", "description": "Single SQL statement to validate"},
+                        "env": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Optional connection overrides as key=value (host, port, user, password, database)",
+                        },
+                    },
+                    "required": ["sql"],
+                },
             },
             {
                 "name": "generate_config",

--- a/src/handler/agent/tools/obdiag_commands.py
+++ b/src/handler/agent/tools/obdiag_commands.py
@@ -41,6 +41,7 @@ OBDIAG_COMMANDS = {
     "rca_run": "obdiag rca run",
     "rca_list": "obdiag rca list",
     "tool_io_performance": "obdiag tool io_performance",
+    "tool_sql_syntax": "obdiag tool sql_syntax",
 }
 
 
@@ -523,3 +524,40 @@ def register_obdiag_tools(agent: Agent[AgentDependencies, str]):
             return f"IO performance check completed successfully.\n\n{output}"
         else:
             return f"IO performance check failed.\n\n{output}"
+
+    @agent.tool
+    def tool_sql_syntax(
+        ctx: RunContext[AgentDependencies],
+        sql: str,
+        env: Optional[List[str]] = None,
+    ) -> str:
+        """
+        Validate SQL on the cluster using EXPLAIN (does not execute the statement).
+
+        Args:
+            sql: Single SQL statement to check
+            env: Optional connection overrides as key=value strings (host, port, user, password, database)
+
+        Returns:
+            Validation result (VALID, SYNTAX_ERROR, or SEMANTIC_ERROR) or error message
+        """
+        deps = ctx.deps
+        arguments: Dict[str, Any] = {"sql": sql}
+        if env:
+            arguments["env"] = env
+
+        result = execute_obdiag_command(
+            "tool_sql_syntax",
+            arguments,
+            deps.config_path,
+            deps.stdio,
+        )
+
+        output = result.get("stdout", "")
+        if result.get("stderr"):
+            output += "\n" + result.get("stderr", "")
+
+        if result.get("success"):
+            return f"SQL syntax check completed.\n\n{output}"
+        else:
+            return f"SQL syntax check failed.\n\n{output}"

--- a/src/handler/agent/toolsets/obdiag.py
+++ b/src/handler/agent/toolsets/obdiag.py
@@ -311,6 +311,29 @@ def tool_io_performance(
     return _run(ctx, "tool_io_performance", args, "IO performance check completed successfully.", "IO performance check failed.", cluster_config_path)
 
 
+@obdiag_toolset.tool
+def tool_sql_syntax(
+    ctx: RunContext[AgentDependencies],
+    sql: str,
+    env: Optional[List[str]] = None,
+    cluster_config_path: Optional[str] = None,
+) -> str:
+    """
+    Validate SQL syntax/semantics on the cluster using EXPLAIN (does not execute the statement).
+
+    Args:
+        sql: Single SQL statement to check
+        env: Optional connection overrides as key=value strings, e.g. host=127.0.0.1 port=2881 user=root@sys
+        cluster_config_path: Path to obdiag config.yml for a non-default cluster
+    """
+    args: dict = {"sql": sql}
+    if env:
+        args["env"] = env
+    valid = {"sql", "env"}
+    result = execute_obdiag_command("tool_sql_syntax", args, _config(ctx, cluster_config_path), ctx.deps.stdio, valid_params=valid)
+    return format_command_output(result, "SQL syntax check completed.", "SQL syntax check failed.")
+
+
 # ---------------------------------------------------------------------------
 # Cluster info tool
 # ---------------------------------------------------------------------------

--- a/src/handler/tools/sql_syntax_handler.py
+++ b/src/handler/tools/sql_syntax_handler.py
@@ -94,10 +94,7 @@ class SqlSyntaxHandler:
     def _get_sql(self):
         sql = Util.get_option(self.options, 'sql')
         if not sql or not sql.strip():
-            self.stdio.error(
-                "--sql is required. Usage: obdiag tool sql_syntax --sql 'SELECT ...' "
-                "[--env host=... --env port=... --env user=... --env password=... --env database=...]"
-            )
+            self.stdio.error("--sql is required. Usage: obdiag tool sql_syntax --sql 'SELECT ...' " "[--env host=... --env port=... --env user=... --env password=... --env database=...]")
             return None
         return sql.strip()
 

--- a/src/handler/tools/sql_syntax_handler.py
+++ b/src/handler/tools/sql_syntax_handler.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# Copyright (c) 2022 OceanBase
+# OceanBase Diagnostic Tool is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+# See the Mulan PSL v2 for more details.
+
+"""
+@time: 2026/03/27
+@file: sql_syntax_handler.py
+@desc: Validate SQL syntax/semantics against a live OceanBase instance
+       using EXPLAIN — without executing the SQL.
+       See https://github.com/oceanbase/obdiag/issues/1181
+"""
+
+import re
+
+import pymysql as mysql
+
+from src.common.ob_connector import OBConnector
+from src.common.result_type import ObdiagResult
+from src.common.tool import StringUtils, Util
+
+
+def normalize_sql_for_syntax_check(sql):
+    """
+    Strip trailing semicolons/whitespace and reject obvious multi-statement input
+    (semicolon followed by more SQL). Reduces risk when prefixing EXPLAIN.
+    Returns (normalized_sql, error_message). error_message is None if OK.
+    """
+    if not sql or not sql.strip():
+        return None, "empty SQL"
+    s = sql.strip()
+    while s.endswith(';'):
+        s = s[:-1].rstrip()
+    if '\x00' in s:
+        return None, "null byte in SQL is not allowed"
+    if re.search(r';\s*\S', s):
+        return None, "multiple statements are not allowed; pass a single statement only"
+    return s, None
+
+
+class SqlSyntaxHandler:
+    def __init__(self, context):
+        self.context = context
+        self.stdio = context.stdio
+        self.options = context.options
+
+    def handle(self):
+        sql = self._get_sql()
+        if sql is None:
+            return ObdiagResult(ObdiagResult.INPUT_ERROR_CODE, error_data="--sql is required")
+
+        sql, norm_err = normalize_sql_for_syntax_check(sql)
+        if norm_err:
+            self.stdio.error(norm_err)
+            return ObdiagResult(ObdiagResult.INPUT_ERROR_CODE, error_data=norm_err)
+
+        host, port, user, password, database = self._resolve_connection()
+        if host is None:
+            return ObdiagResult(ObdiagResult.INPUT_ERROR_CODE, error_data="missing connection info")
+
+        db_label = "database: {0}".format(database) if database else "no database selected"
+        self.stdio.print("SQL syntax check on {0}:{1} (user: {2}, {3})".format(host, port, user, db_label))
+        self.stdio.print("SQL: {0}".format(sql))
+
+        connector = OBConnector(
+            context=self.context,
+            ip=host,
+            port=port,
+            username=user,
+            password=password or '',
+            database=database,
+        )
+        if connector.conn is None:
+            self.stdio.error("Failed to connect to OceanBase at {0}:{1}. Check your connection info.".format(host, port))
+            return ObdiagResult(ObdiagResult.SERVER_ERROR_CODE, error_data="connection failed")
+
+        try:
+            return self._check_syntax(connector, sql)
+        finally:
+            if getattr(connector, "conn", None) is not None:
+                try:
+                    connector.conn.close()
+                except Exception:
+                    pass
+
+    # ------------------------------------------------------------------
+    def _get_sql(self):
+        sql = Util.get_option(self.options, 'sql')
+        if not sql or not sql.strip():
+            self.stdio.error(
+                "--sql is required. Usage: obdiag tool sql_syntax --sql 'SELECT ...' "
+                "[--env host=... --env port=... --env user=... --env password=... --env database=...]"
+            )
+            return None
+        return sql.strip()
+
+    def _resolve_connection(self):
+        """Return (host, port, user, password, database) using --env first, then config.yml fallback."""
+        env_list = Util.get_option(self.options, 'env')
+        env_dict = StringUtils.parse_env_display(env_list) if env_list else {}
+
+        if env_dict:
+            db_info = StringUtils.build_db_info_from_env(env_dict, self.stdio)
+            if db_info is None:
+                return None, None, None, None, None
+            host = db_info.get('host')
+            port = db_info.get('port')
+            user = db_info.get('user')
+            password = db_info.get('password', '')
+            database = db_info.get('database')
+            if host and port and user:
+                return host, int(port), user, password, database
+            self.stdio.warn("Incomplete connection info in --env (need host, port, user), falling back to config.yml obcluster")
+
+        cluster_config = self.context.cluster_config or {}
+        host = cluster_config.get('db_host')
+        port = cluster_config.get('db_port')
+        tenant_sys = cluster_config.get('tenant_sys') or {}
+        user = tenant_sys.get('user')
+        password = tenant_sys.get('password', '')
+        database = env_dict.get('database') or env_dict.get('db')
+
+        if not host or not port or not user:
+            self.stdio.error("Missing connection info. Provide via --env or set obcluster.db_host / db_port / tenant_sys.user in config.yml.")
+            return None, None, None, None, None
+
+        return host, int(port), user, password, database
+
+    def _check_syntax(self, connector, sql):
+        """Run EXPLAIN against the SQL and interpret the result."""
+        explain_sql = "EXPLAIN {0}".format(sql)
+        self.stdio.verbose("[sql-syntax] exec: {0}".format(explain_sql))
+
+        try:
+            connector.execute_sql(explain_sql)
+            self.stdio.print("Result: VALID")
+            return ObdiagResult(ObdiagResult.SUCCESS_CODE, data={"result": "VALID", "sql": sql})
+
+        except mysql.Error as e:
+            error_code = e.args[0] if e.args else None
+            error_msg = e.args[1] if len(e.args) > 1 else str(e)
+
+            if error_code == 1064:
+                self.stdio.print("Result: SYNTAX ERROR")
+                self.stdio.print("Detail: {0}".format(error_msg))
+                return ObdiagResult(
+                    ObdiagResult.SUCCESS_CODE,
+                    data={"result": "SYNTAX_ERROR", "error_code": error_code, "detail": error_msg},
+                )
+            else:
+                self.stdio.print("Result: VALID (syntax OK, but semantic error [{0}]: {1})".format(error_code, error_msg))
+                return ObdiagResult(
+                    ObdiagResult.SUCCESS_CODE,
+                    data={"result": "SEMANTIC_ERROR", "error_code": error_code, "detail": error_msg},
+                )
+
+        except Exception as e:
+            self.stdio.error("Unexpected error during SQL syntax check: {0}".format(e))
+            return ObdiagResult(ObdiagResult.SERVER_ERROR_CODE, error_data=str(e))


### PR DESCRIPTION
- Introduced `ObdiagToolSqlSyntaxCommand` to validate SQL statements against a live OceanBase instance using EXPLAIN without executing the statement.
- Implemented `tool_sql_syntax` method in `ObdiagHome` to handle the SQL syntax validation logic.
- Created `SqlSyntaxHandler` to manage the SQL validation process, including connection handling and error reporting.
- Updated command registration in `MCPServer` and `obdiag_commands.py` to include the new SQL syntax tool.
- Enhanced documentation for the SQL syntax validation feature, detailing usage and connection options.


- close #1181 