### PR TITLE
feat(agent): improve non-interactive TUI workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ dev_docs/
 build/
 rpmbuild/
 .cursor/
+.claude/
+scripts/
+deepagents/

--- a/src/common/constant.py
+++ b/src/common/constant.py
@@ -28,7 +28,7 @@ def get_obdiag_workspace():
     获取 obdiag 工作空间路径（已展开的绝对路径）。
     优先使用环境变量 OBDIAG_HOME，未设置时使用默认值 ~/.obdiag。
     """
-    return os.path.expanduser(os.environ.get(OBDIAG_HOME_ENV, OBDIAG_WORKSPACE_DEFAULT))
+    return os.path.abspath(os.path.expanduser(os.environ.get(OBDIAG_HOME_ENV, OBDIAG_WORKSPACE_DEFAULT)))
 
 
 def obdiag_path(*parts):
@@ -48,7 +48,7 @@ def expand_obdiag_path(path):
     if path and isinstance(path, str) and path.startswith("~/.obdiag"):
         suffix = path[len("~/.obdiag") :].lstrip("/")
         return obdiag_path(suffix) if suffix else get_obdiag_workspace()
-    return os.path.expanduser(path) if path else path
+    return os.path.abspath(os.path.expanduser(path)) if path else path
 
 
 class _const:

--- a/src/common/diag_cmd.py
+++ b/src/common/diag_cmd.py
@@ -1318,18 +1318,28 @@ class ObdiagAgentCommand(ObdiagOriginCommand):
         super(ObdiagAgentCommand, self).__init__('agent', 'obdiag agent. Interactive diagnostic agent for obdiag (BETA)')
         self.parser.add_option('-c', type='string', help='obdiag custom config', default=os.path.expanduser('~/.obdiag/config.yml'))
         self.parser.add_option('--config', action="append", type="string", help='config options Format: --config key=value')
-        self.parser.add_option('-m', '--message', type='string', help='single-shot message to send to the agent', default=None)
-        self.parser.add_option('--resume', type='string', help='resume a previous session by ID (see "sessions" command)', default=None)
-        self.parser.add_option('-y', '--yolo', action='store_true', dest='yolo', help='auto-approve all tools (for testing with -m)', default=False)
+        self.parser.add_option('-n', '--non-interactive', type='string', dest='non_interactive_message', help='Run a single task non-interactively and exit', default=None)
+        self.parser.add_option('-q', '--quiet', action='store_true', dest='quiet', help='Clean output for piping (stdout = agent response only). Requires -n.', default=False)
+        self.parser.add_option('--no-stream', action='store_true', dest='no_stream', help='Buffer full response, write to stdout at once. Requires -n.', default=False)
+        self.parser.add_option('-r', '--resume', action='callback', callback=self._parse_resume, dest='resume_thread', help='Resume thread: -r for most recent, -r <ID> for specific thread', default=None)
+
+    @staticmethod
+    def _parse_resume(option, opt_str, value, parser):
+        """Callback for -r/--resume: bare -r means most recent, -r <ID> means specific thread."""
+        if parser.rargs and not parser.rargs[0].startswith('-'):
+            setattr(parser.values, option.dest, parser.rargs.pop(0))
+        else:
+            setattr(parser.values, option.dest, "__MOST_RECENT__")
 
     def init(self, cmd, args):
         super(ObdiagAgentCommand, self).init(cmd, args)
         self.parser.set_usage(
             '%s [options]\n\n'
             '  Interactive mode:   obdiag agent\n'
-            '  Single-shot mode:   obdiag agent -m "帮我巡检一下集群"\n'
-            '  Resume session:     obdiag agent --resume 20260313_142055\n'
-            '  Resume + message:   obdiag agent --resume 20260313_142055 -m "这些文件有多大"  (for testing)\n'
+            '  Non-interactive:    obdiag agent -n "帮我巡检一下集群"\n'
+            '  Quiet (pipe):       obdiag agent -n "检查集群状态" -q\n'
+            '  Resume (recent):    obdiag agent -r\n'
+            '  Resume (by ID):     obdiag agent -r 20260313_142055\n'
             '  Target cluster:     obdiag agent -c obdiag_test' % self.prev_cmd
         )
         return self

--- a/src/common/ob_connector.py
+++ b/src/common/ob_connector.py
@@ -22,6 +22,25 @@ from prettytable import from_db_cursor
 import pymysql as mysql
 
 
+class _NullStdio:
+    """Silent stdio fallback when no context is provided."""
+
+    def verbose(self, *args, **kwargs):
+        pass
+
+    def warn(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+    def print(self, *args, **kwargs):
+        pass
+
+    def exception(self, *args, **kwargs):
+        pass
+
+
 class OBConnector(object):
     # sql be upper
     filter_sql_list = []
@@ -44,7 +63,7 @@ class OBConnector(object):
         self.password = str(password)
         self.timeout = timeout
         self.conn = None
-        self.stdio = context.stdio
+        self.stdio = context.stdio if context else _NullStdio()
         self.database = database
         self.init()
 

--- a/src/handler/agent/handler.py
+++ b/src/handler/agent/handler.py
@@ -216,7 +216,8 @@ Your capabilities include:
 Multi-cluster support:
 - Default cluster config is ~/.obdiag/config.yml. Other configs are *.yml/*.yaml in the same directory.
 - When the user asks which clusters exist, call list_obdiag_clusters first.
-- Every diagnostic tool accepts an optional cluster_config_path parameter (short name or full path).
+- In interactive TUI, use `/use <short_name|full_path>` only when the user wants to switch the active cluster for the rest of the session.
+- For one-off diagnostics on another cluster, prefer passing cluster_config_path (short name or full path) to the tool instead of switching.
 
 Tool selection for gather operations:
 - gather_log: Observer-side logs only (observer/election/rootservice).
@@ -229,6 +230,11 @@ Tool selection for gather operations:
 After a gather completes, if the user asks to analyze logs:
 - Use ls and read_file on the gather output directory to locate and read relevant files, then summarize.
 - analyze_log is ONLY for OceanBase cluster observer-node log analysis.
+
+Path handling:
+- ALWAYS use absolute paths for config files, log files, and output directories. Never use relative paths like ./check_report or ./obdiag_rca.
+- When displaying paths to the user, show the fully resolved absolute path.
+- When passing cluster_config_path to tools, use absolute paths or short names (which are resolved internally).
 
 User experience guidelines:
 - Respond in the same language as the user's question.
@@ -277,12 +283,15 @@ class AiAgentHandler:
             create_obdiag_tools(config_path_getter, self.stdio) + create_db_tools(deps_getter) + create_config_gen_tools(self.stdio) + (create_knowledge_tools(lambda: config.oceanbase_knowledge_bearer_token) if config.oceanbase_knowledge_enabled else [])
         )
 
-        msg = Util.get_option(self.options, "m")
+        msg = Util.get_option(self.options, "non_interactive_message")
+        quiet = Util.get_option(self.options, "quiet", False)
+        no_stream = Util.get_option(self.options, "no_stream", False)
+        resume_thread = Util.get_option(self.options, "resume_thread")
 
         try:
             if msg:
-                return self._run_single_shot(msg, obdiag_tools, config)
-            return self._run_interactive(obdiag_tools, config)
+                return self._run_single_shot(msg, obdiag_tools, config, quiet=quiet, stream=not no_stream)
+            return self._run_interactive(obdiag_tools, config, resume_thread=resume_thread)
         finally:
             if self._deps:
                 self._deps.close()
@@ -291,15 +300,13 @@ class AiAgentHandler:
     # Interactive mode — full Textual TUI via vendored tui/
     # ------------------------------------------------------------------
 
-    def _run_interactive(self, obdiag_tools: list, config: AgentConfig) -> ObdiagResult:
+    def _run_interactive(self, obdiag_tools: list, config: AgentConfig, *, resume_thread: Optional[str] = None) -> ObdiagResult:
         from src.handler.agent.tui.agent import create_cli_agent
         from src.handler.agent.tui.app import run_textual_app
         from src.handler.agent.tui.config import create_model
         from src.handler.agent.tui.sessions import generate_thread_id, get_checkpointer
 
         async def _run() -> Any:
-            # create_model() reads [models].default / [models].recent from
-            # ~/.obdiag/config/agent.toml via deepagents-cli's ModelConfig.load()
             model_result = create_model()
             model_result.apply_to_settings()
             model = model_result.model
@@ -316,12 +323,29 @@ class AiAgentHandler:
                     extra_interrupt_on=obdiag_interrupt_on,
                     checkpointer=checkpointer,
                 )
-                thread_id = generate_thread_id()
+                thread_id = None if resume_thread else generate_thread_id()
+
+                def use_cluster(config_path: str) -> tuple[bool, str]:
+                    if self._deps is None:
+                        return False, "Agent dependencies are not initialized."
+                    ok, message = self._deps.switch_cluster(config_path)
+                    if ok:
+                        self._config_path_ref["v"] = self._deps.config_path
+                    return ok, message
+
+                def current_cluster_info() -> str:
+                    if self._deps is None:
+                        return "Agent dependencies are not initialized."
+                    return self._deps.current_cluster_info()
+
                 return await run_textual_app(
                     agent=agent,
                     backend=backend,
                     assistant_id=_ASSISTANT_ID,
                     thread_id=thread_id,
+                    resume_thread=resume_thread,
+                    use_cluster=use_cluster,
+                    current_cluster_info=current_cluster_info,
                 )
 
         try:
@@ -329,6 +353,9 @@ class AiAgentHandler:
             return ObdiagResult(ObdiagResult.SUCCESS_CODE, data={"message": "Agent session ended", "thread_id": app_result.thread_id or ""})
         except KeyboardInterrupt:
             return ObdiagResult(ObdiagResult.SUCCESS_CODE, data={"message": "Agent session interrupted"})
+        except (BrokenPipeError, OSError) as e:
+            _LOG.info("Terminal connection lost: %s", e)
+            return ObdiagResult(ObdiagResult.SUCCESS_CODE, data={"message": "Terminal connection lost"})
         except Exception as e:
             _LOG.exception("Interactive agent session error")
             return ObdiagResult(ObdiagResult.SERVER_ERROR_CODE, error_data=str(e))
@@ -337,7 +364,7 @@ class AiAgentHandler:
     # Single-shot mode — async streaming, no TUI
     # ------------------------------------------------------------------
 
-    def _run_single_shot(self, msg: str, obdiag_tools: list, config: AgentConfig) -> ObdiagResult:
+    def _run_single_shot(self, msg: str, obdiag_tools: list, config: AgentConfig, *, quiet: bool = False, stream: bool = True) -> ObdiagResult:
         from src.handler.agent.tui.agent import create_cli_agent
         from src.handler.agent.tui.config import build_stream_config, create_model
         from src.handler.agent.tui.file_ops import FileOpTracker
@@ -363,9 +390,9 @@ class AiAgentHandler:
                 )
                 thread_id = generate_thread_id()
                 lc_config = build_stream_config(thread_id, _ASSISTANT_ID)
-                console = Console()
+                console = Console(stderr=True) if quiet else Console()
                 file_op_tracker = FileOpTracker(assistant_id=_ASSISTANT_ID, backend=None)
-                await _run_agent_loop(agent, msg, lc_config, console, file_op_tracker)
+                await _run_agent_loop(agent, msg, lc_config, console, file_op_tracker, quiet=quiet, stream=stream)
 
         try:
             asyncio.run(_run())

--- a/src/handler/agent/models.py
+++ b/src/handler/agent/models.py
@@ -16,6 +16,7 @@
 @desc: Data models for the obdiag agent
 """
 
+import logging
 import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
@@ -65,7 +66,7 @@ def discover_obcluster_configs() -> List[Dict[str, Any]]:
     for name in sorted(os.listdir(root), key=str.lower):
         if name.startswith("."):
             continue
-        if not (name.endswith(".yml") or name.endswith(".yaml")):
+        if not name.endswith(".yml"):
             continue
         path = os.path.join(root, name)
         if not os.path.isfile(path):
@@ -87,7 +88,7 @@ def discover_obcluster_configs() -> List[Dict[str, Any]]:
         )
 
     entries.sort(key=lambda e: (not e["is_default"], e["file_name"].lower()))
-    return entries
+    return [e for e in entries if e["has_obcluster"]]
 
 
 def _build_connector_from_cluster_config(
@@ -113,6 +114,7 @@ def _build_connector_from_cluster_config(
         password = ""
 
     if not db_host or not db_port or not username:
+        logging.getLogger(__name__).warning("Cannot build OBConnector: missing db_host=%s, db_port=%s, user=%s", db_host, db_port, username)
         return None
 
     try:
@@ -124,7 +126,8 @@ def _build_connector_from_cluster_config(
             password=password,
             timeout=100,
         )
-    except Exception:
+    except Exception as e:
+        logging.getLogger(__name__).warning("OBConnector failed to connect to %s:%s — %s", db_host, db_port, e)
         return None
 
 

--- a/src/handler/agent/toolsets/config_gen.py
+++ b/src/handler/agent/toolsets/config_gen.py
@@ -26,6 +26,15 @@ import yaml
 from src.common.constant import obdiag_path
 
 
+def _redact_passwords(obj: Any) -> Any:
+    """Deep-copy a config dict, replacing values whose keys contain 'password' with '***'."""
+    if isinstance(obj, dict):
+        return {k: ("***" if "password" in k.lower() else _redact_passwords(v)) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_redact_passwords(item) for item in obj]
+    return obj
+
+
 def _validate_config_args(arguments: Dict[str, Any]) -> Optional[str]:
     """Return an error message string if required fields are missing, else None."""
     missing = []
@@ -252,7 +261,8 @@ def create_config_gen_tools(stdio: Any = None) -> list:
             msg = f"Configuration file generated successfully!\n\nOutput: {output_path}\nSize: {file_size} bytes\n"
             if backup_path:
                 msg += f"Backup: {backup_path}\n"
-            msg += "\n" + yaml.dump(config, default_flow_style=False, allow_unicode=True, sort_keys=False)
+            redacted = _redact_passwords(config)
+            msg += "\n" + yaml.dump(redacted, default_flow_style=False, allow_unicode=True, sort_keys=False)
 
             if stdio:
                 stdio.verbose(f"Config generated at {output_path}")

--- a/src/handler/agent/toolsets/database.py
+++ b/src/handler/agent/toolsets/database.py
@@ -51,7 +51,13 @@ def create_db_tools(deps_getter: Callable[[], AgentDependencies]) -> list:
         if not connector:
             if cluster_config_path:
                 return f"Error: Cannot connect to cluster from config '{cluster_config_path}'. " "Please verify the file exists and contains valid 'obcluster' settings " "(db_host, db_port, tenant_sys.user; tenant_sys.password may be empty)."
-            return "Error: No database connection available. " "Use `/use <config_path>` in the agent REPL to switch cluster, or pass cluster_config_path."
+            cfg_file = deps.config_path or "(not set)"
+            return (
+                f"Error: No database connection available (config: {cfg_file}). "
+                "Check that db_host, db_port, and tenant_sys.user are correct in the config. "
+                "You can pass cluster_config_path to specify a different cluster. "
+                "Check agent logs for connection error details."
+            )
 
         target = cluster_config_path or deps.config_path or "default cluster"
         try:

--- a/src/handler/agent/toolsets/obdiag.py
+++ b/src/handler/agent/toolsets/obdiag.py
@@ -63,6 +63,8 @@ def truncate_for_agent(
 
 OBDIAG_COMMANDS = {
     "gather_log": "obdiag gather log",
+    "gather_scene_run": "obdiag gather scene run",
+    "gather_scene_list": "obdiag gather scene list",
     "gather_plan_monitor": "obdiag gather plan_monitor",
     "gather_sysstat": "obdiag gather sysstat",
     "gather_perf": "obdiag gather perf",
@@ -90,6 +92,8 @@ OBDIAG_TOOL_SUMMARY_ZH: Dict[str, str] = {
     "gather_ash": "采集 ASH 活跃会话历史",
     "gather_awr": "采集 AWR / 性能报告",
     "gather_plan_monitor": "按 trace_id 采集 SQL 计划监控",
+    "gather_scene_run": "执行 gather scene 场景采集",
+    "gather_scene_list": "列出可用 gather scene 场景",
     "analyze_log": "分析集群 observer 侧日志",
     "check_cluster": "执行集群健康巡检",
     "check_list": "列出可用巡检项",
@@ -282,6 +286,8 @@ def _resolve_config(override: Optional[str], config_path_getter: Callable[[], st
 
 
 def _run(cmd: str, args: dict, cfg: str, ok: str, fail: str, stdio) -> str:
+    if "store_dir" in args and args["store_dir"]:
+        args["store_dir"] = os.path.abspath(os.path.expanduser(args["store_dir"]))
     result = execute_obdiag_command(cmd, args, cfg, stdio)
     return truncate_for_agent(format_command_output(result, ok, fail), label="obdiag")
 
@@ -573,6 +579,66 @@ def create_obdiag_tools(config_path_getter: Callable[[], str], stdio) -> list:
             args["store_dir"] = store_dir
         return _run("gather_plan_monitor", args, cfg, "Plan monitor gathering completed.", "Plan monitor gathering failed.", stdio)
 
+    def gather_scene_run(
+        scene: str,
+        since: Optional[str] = "30m",
+        from_time: Optional[str] = None,
+        to_time: Optional[str] = None,
+        env: Optional[List[str]] = None,
+        store_dir: Optional[str] = None,
+        temp_dir: Optional[str] = None,
+        skip_type: Optional[str] = None,
+        redact: Optional[str] = None,
+        cluster_config_path: Optional[str] = None,
+    ) -> str:
+        """Run a gather scene (obdiag gather scene run).
+
+        Use for YAML/Python-defined scene tasks under plugins/gather/tasks, e.g. observer.cluster_down,
+        observer.memory, observer.io, obproxy.restart, or other.application_error.
+
+        Args:
+            scene: Gather scene name, e.g. "observer.cluster_down"; multiple scenes can be separated by ";" or ","
+            since: Relative window e.g. '30m', '1h', '2d'. Ignored by obdiag when both from_time and to_time are provided.
+            from_time: Start time yyyy-mm-dd hh:mm:ss
+            to_time: End time yyyy-mm-dd hh:mm:ss
+            env: Scene env overrides as key=value strings, e.g. host=127.0.0.1 port=2881 user=root@sys
+            store_dir: Output directory
+            temp_dir: Temp dir on remote nodes
+            skip_type: Skip gather type, choices include ssh or sql
+            redact: Desensitization options
+            cluster_config_path: Short name or full path for non-default cluster
+        """
+        cfg = _resolve_config(cluster_config_path, config_path_getter)
+        args: dict = {"scene": scene}
+        if from_time:
+            args["from"] = from_time
+        if to_time:
+            args["to"] = to_time
+        if since and not (from_time and to_time):
+            args["since"] = since
+        if env:
+            args["env"] = env
+        if store_dir:
+            args["store_dir"] = store_dir
+        if temp_dir:
+            args["temp_dir"] = temp_dir
+        if skip_type:
+            args["skip_type"] = skip_type
+        if redact:
+            args["redact"] = redact
+        return _run("gather_scene_run", args, cfg, "Gather scene completed.", "Gather scene failed.", stdio)
+
+    def gather_scene_list() -> str:
+        """List all available gather scenes (obdiag gather scene list).
+
+        Call this when the user asks which gather scenes exist, or before choosing a scene name.
+        """
+        result = execute_obdiag_command("gather_scene_list", {}, None, stdio)
+        output = result.get("stdout", "")
+        if result.get("stderr"):
+            output += "\n" + result["stderr"]
+        return truncate_for_agent(f"Available gather scenes:\n\n{output}", label="obdiag")
+
     def analyze_log(
         files: Optional[List[str]] = None,
         from_time: Optional[str] = None,
@@ -643,14 +709,13 @@ def create_obdiag_tools(config_path_getter: Callable[[], str], stdio) -> list:
             args["store_dir"] = store_dir
         return _run("check", args, cfg, "Health check completed.", "Health check failed.", stdio)
 
-    def check_list(cluster_config_path: Optional[str] = None) -> str:
+    def check_list() -> str:
         """List all available health check tasks.
 
         Args:
             cluster_config_path: Optional short name or full path for non-default cluster.
         """
-        cfg = _resolve_config(cluster_config_path, config_path_getter)
-        result = execute_obdiag_command("check_list", {}, cfg, stdio)
+        result = execute_obdiag_command("check_list", {}, None, stdio)
         output = result.get("stdout", "")
         if result.get("stderr"):
             output += "\n" + result["stderr"]
@@ -669,14 +734,13 @@ def create_obdiag_tools(config_path_getter: Callable[[], str], stdio) -> list:
         cfg = _resolve_config(cluster_config_path, config_path_getter)
         return _run("rca_run", {"scene": scene}, cfg, "Root cause analysis completed.", "Root cause analysis failed.", stdio)
 
-    def rca_list(cluster_config_path: Optional[str] = None) -> str:
+    def rca_list() -> str:
         """List all available root cause analysis scenarios (obdiag rca list).
 
         Args:
             cluster_config_path: Optional short name or full path for non-default cluster.
         """
-        cfg = _resolve_config(cluster_config_path, config_path_getter)
-        result = execute_obdiag_command("rca_list", {}, cfg, stdio)
+        result = execute_obdiag_command("rca_list", {}, None, stdio)
         output = result.get("stdout", "")
         if result.get("stderr"):
             output += "\n" + result["stderr"]
@@ -760,6 +824,8 @@ def create_obdiag_tools(config_path_getter: Callable[[], str], stdio) -> list:
         gather_ash,
         gather_awr,
         gather_plan_monitor,
+        gather_scene_run,
+        gather_scene_list,
         analyze_log,
         check_cluster,
         check_list,

--- a/src/handler/agent/tui/agent.py
+++ b/src/handler/agent/tui/agent.py
@@ -951,6 +951,10 @@ def create_cli_agent(
     agent_middleware = []
     agent_middleware.append(ConfigurableModelMiddleware())
 
+    from src.handler.agent.tui.tool_call_repair import ToolCallRepairMiddleware
+
+    agent_middleware.append(ToolCallRepairMiddleware())
+
     # Token state: adds _context_tokens to graph state (checkpointed, not
     # passed to model).  Must be registered before any middleware that might
     # read the channel.
@@ -972,7 +976,7 @@ def create_cli_agent(
 
         agent_middleware.append(
             MemoryMiddleware(
-                backend=FilesystemBackend(),
+                backend=FilesystemBackend(virtual_mode=False),
                 sources=memory_sources,
             )
         )
@@ -990,19 +994,11 @@ def create_cli_agent(
         if project_agent_skills_dir:
             sources.append(str(project_agent_skills_dir))
 
-        # Experimental: Claude Code skill directories
-        user_claude_skills_dir = settings.get_user_claude_skills_dir()
-        if user_claude_skills_dir.exists():
-            sources.append(str(user_claude_skills_dir))
-        project_claude_skills_dir = settings.get_project_claude_skills_dir()
-        if project_claude_skills_dir:
-            sources.append(str(project_claude_skills_dir))
-
         from src.handler.agent.tui.skills.skill_crypto import DecryptingFilesystemBackend
 
         agent_middleware.append(
             SkillsMiddleware(
-                backend=DecryptingFilesystemBackend(FilesystemBackend()),
+                backend=DecryptingFilesystemBackend(FilesystemBackend(virtual_mode=False)),
                 sources=sources,
             )
         )
@@ -1023,12 +1019,13 @@ def create_cli_agent(
             # on the execute tool natively.
             backend = LocalShellBackend(
                 root_dir=root_dir,
+                virtual_mode=False,
                 inherit_env=True,
                 env=shell_env,
             )
         else:
             # No shell access - use plain FilesystemBackend
-            backend = FilesystemBackend(root_dir=root_dir)
+            backend = FilesystemBackend(root_dir=root_dir, virtual_mode=False)
     else:
         # ========== REMOTE SANDBOX MODE ==========
         backend = sandbox  # Remote sandbox (ModalSandbox, etc.)

--- a/src/handler/agent/tui/app.py
+++ b/src/handler/agent/tui/app.py
@@ -19,6 +19,7 @@ import time
 import uuid
 import webbrowser
 from collections import deque
+from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -224,6 +225,46 @@ def save_theme_preference(name: str) -> bool:
         logger.exception("Could not save theme preference")
         return False
     return True
+
+
+def _get_version_info_text() -> str:
+    """Return obdiag agent version information for the `/version` command."""
+    try:
+        from src.common.version import OBDIAG_VERSION
+
+        obdiag_line = f"obdiag version: {OBDIAG_VERSION}"
+    except ImportError:
+        logger.debug("src.common.version module not found")
+        obdiag_line = "obdiag version: unknown"
+    except Exception:
+        logger.warning("Unexpected error looking up obdiag version", exc_info=True)
+        obdiag_line = "obdiag version: unknown"
+
+    try:
+        from src.handler.agent.tui._version import (
+            __version__ as cli_version,
+        )
+
+        cli_line = f"deepagents-cli version: {cli_version}"
+    except ImportError:
+        logger.debug("deepagents_cli._version module not found")
+        cli_line = "deepagents-cli version: unknown"
+    except Exception:
+        logger.warning("Unexpected error looking up CLI version", exc_info=True)
+        cli_line = "deepagents-cli version: unknown"
+
+    try:
+        from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+        sdk_version = _pkg_version("deepagents")
+        sdk_line = f"deepagents (SDK) version: {sdk_version}"
+    except PackageNotFoundError:
+        logger.debug("deepagents SDK package not found in environment")
+        sdk_line = "deepagents (SDK) version: unknown"
+    except Exception:
+        logger.warning("Unexpected error looking up SDK version", exc_info=True)
+        sdk_line = "deepagents (SDK) version: unknown"
+    return f"{obdiag_line}\n{cli_line}\n{sdk_line}"
 
 
 def _extract_model_params_flag(raw_arg: str) -> tuple[str, dict[str, Any] | None]:
@@ -814,6 +855,8 @@ ChatTextArea {
         server_kwargs: dict[str, Any] | None = None,
         mcp_preload_kwargs: dict[str, Any] | None = None,
         model_kwargs: dict[str, Any] | None = None,
+        use_cluster: Callable[[str], tuple[bool, str]] | None = None,
+        current_cluster_info: Callable[[], str] | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the Deep Agents application.
@@ -857,6 +900,8 @@ ChatTextArea {
 
                 When provided, model creation runs in a background worker after
                 first paint instead of blocking startup.
+            use_cluster: Optional callback used by `/use <config>` to switch the active obdiag cluster.
+            current_cluster_info: Optional callback used by `/use` with no argument to show current cluster.
             **kwargs: Additional arguments passed to parent
         """
         super().__init__(**kwargs)
@@ -899,6 +944,8 @@ ChatTextArea {
         self._mcp_preload_kwargs = mcp_preload_kwargs
 
         self._model_kwargs = model_kwargs
+        self._use_cluster = use_cluster
+        self._current_cluster_info = current_cluster_info
 
         self._connecting = server_kwargs is not None
         # Extract sandbox type from server kwargs for trace metadata.
@@ -1236,12 +1283,8 @@ ChatTextArea {
             group="startup-thread-prewarm",
         )
 
-        # Optional tool warnings in a thread (shutil.which is sync I/O)
-        self.run_worker(
-            self._check_optional_tools_background,
-            exclusive=True,
-            group="startup-tool-check",
-        )
+        # Optional tool warnings (ripgrep, tavily) disabled for obdiag agent —
+        # these tools are not required for OceanBase diagnostics.
 
         # Auto-submit initial prompt or skill if provided via -m / --skill.
         # This check must come first because _lc_thread_id and _agent are
@@ -2646,7 +2689,7 @@ ChatTextArea {
                 "Commands: /quit, /clear, /offload, /editor, /mcp, "
                 "/model [--model-params JSON] [--default], /notifications, "
                 "/reload, /skill:<name>, /remember, /skill-creator, /theme, "
-                "/tokens, /threads, /trace, "
+                "/tokens, /threads, /trace, /use <cluster>, "
                 "/update, /auto-update, /changelog, /docs, /feedback, /help\n\n"
                 "Interactive Features:\n"
                 "  Enter           Submit your message\n"
@@ -2668,34 +2711,7 @@ ChatTextArea {
             await self._open_url_command(command, cmd)
         elif cmd == "/version":
             await self._mount_message(UserMessage(command))
-            # Show CLI and SDK package versions
-            try:
-                from src.handler.agent.tui._version import (
-                    __version__ as cli_version,
-                )
-
-                cli_line = f"deepagents-cli version: {cli_version}"
-            except ImportError:
-                logger.debug("deepagents_cli._version module not found")
-                cli_line = "deepagents-cli version: unknown"
-            except Exception:
-                logger.warning("Unexpected error looking up CLI version", exc_info=True)
-                cli_line = "deepagents-cli version: unknown"
-            try:
-                from importlib.metadata import (
-                    PackageNotFoundError,
-                    version as _pkg_version,
-                )
-
-                sdk_version = _pkg_version("deepagents")
-                sdk_line = f"deepagents (SDK) version: {sdk_version}"
-            except PackageNotFoundError:
-                logger.debug("deepagents SDK package not found in environment")
-                sdk_line = "deepagents (SDK) version: unknown"
-            except Exception:
-                logger.warning("Unexpected error looking up SDK version", exc_info=True)
-                sdk_line = "deepagents (SDK) version: unknown"
-            await self._mount_message(AppMessage(f"{cli_line}\n{sdk_line}"))
+            await self._mount_message(AppMessage(_get_version_info_text()))
         elif cmd == "/clear":
             self._pending_messages.clear()
             self._queued_widgets.clear()
@@ -2768,6 +2784,21 @@ ChatTextArea {
                     parts.append(model_name)
 
                 await self._mount_message(AppMessage(" · ".join(parts)))
+        elif cmd == "/use" or cmd.startswith("/use "):
+            await self._mount_message(UserMessage(command))
+            arg = command.strip()[len("/use") :].strip()
+            if not self._use_cluster:
+                await self._mount_message(AppMessage("Cluster switching is not available in this session."))
+                return
+            if not arg:
+                current = self._current_cluster_info() if self._current_cluster_info else "Current cluster is unavailable."
+                await self._mount_message(AppMessage(f"{current}\n\nUsage: /use <short_name|full_config_path>"))
+                return
+            ok, message = await asyncio.to_thread(self._use_cluster, arg)
+            if ok:
+                await self._mount_message(AppMessage(message))
+            else:
+                await self._mount_message(ErrorMessage(message))
         elif cmd == "/remember" or cmd.startswith("/remember "):
             # Convenience alias for /skill:remember — shorter and discoverable
             # before skill loading completes.
@@ -3912,15 +3943,23 @@ ChatTextArea {
             worker.cancel()
 
     def action_quit_or_interrupt(self) -> None:
-        """Handle Ctrl+C - interrupt agent, reject approval, or quit on double press.
+        """Handle Ctrl+C - copy selection, interrupt agent, reject approval, or quit on double press.
 
         Priority order:
+        0. If text is selected anywhere, copy to clipboard
         1. If shell command is running, kill it
         2. If approval menu is active, reject it
         3. If agent is running, interrupt it (preserve input)
         4. If double press (quit_pending), quit
         5. Otherwise show quit hint
         """
+        from src.handler.agent.tui.clipboard import copy_selection_to_clipboard
+
+        if self._has_text_selection():
+            copy_selection_to_clipboard(self)
+            self.notify("Copied to clipboard", timeout=2)
+            return
+
         # If shell command is running, cancel the worker
         if self._shell_running and self._shell_worker:
             self._cancel_worker(self._shell_worker)
@@ -3954,6 +3993,15 @@ ChatTextArea {
             self.exit()
         else:
             self._arm_quit_pending("Ctrl+C")
+
+    def _has_text_selection(self) -> bool:
+        """Check if any widget in the app has selected text."""
+        for widget in self.query("*"):
+            if not hasattr(widget, "text_selection") or not widget.text_selection:
+                continue
+            if widget.text_selection.end is not None:
+                return True
+        return False
 
     def _arm_quit_pending(self, shortcut: str) -> None:
         """Set the pending-quit flag and show a matching hint.
@@ -4106,7 +4154,10 @@ ChatTextArea {
             _dispatch_hook_sync("session.end", payload, hooks)
 
         _write_iterm_escape(_ITERM_CURSOR_GUIDE_ON)
-        super().exit(result=result, return_code=return_code, message=message)
+        try:
+            super().exit(result=result, return_code=return_code, message=message)
+        except OSError:
+            pass
 
     def action_toggle_auto_approve(self) -> None:
         """Toggle auto-approve mode for the current session.
@@ -4795,6 +4846,8 @@ async def run_textual_app(
     server_kwargs: dict[str, Any] | None = None,
     mcp_preload_kwargs: dict[str, Any] | None = None,
     model_kwargs: dict[str, Any] | None = None,
+    use_cluster: Callable[[str], tuple[bool, str]] | None = None,
+    current_cluster_info: Callable[[], str] | None = None,
 ) -> AppResult:
     """Run the Textual application.
 
@@ -4832,6 +4885,8 @@ async def run_textual_app(
 
             When provided, model creation runs in a background worker after
             first paint so the splash screen appears immediately.
+        use_cluster: Optional callback used by `/use <config>` to switch the active obdiag cluster.
+        current_cluster_info: Optional callback used by `/use` with no argument to show current cluster.
 
     Returns:
         An `AppResult` with the return code and final thread ID.
@@ -4852,10 +4907,34 @@ async def run_textual_app(
         server_kwargs=server_kwargs,
         mcp_preload_kwargs=mcp_preload_kwargs,
         model_kwargs=model_kwargs,
+        use_cluster=use_cluster,
+        current_cluster_info=current_cluster_info,
     )
+    # Register SIGHUP handler so the app exits cleanly when the terminal
+    # disconnects (e.g. SSH session drops).  Without this, Textual's render
+    # loop keeps writing ANSI escape sequences to the now-dead pty, producing
+    # a stream of garbled control codes.
+    loop = asyncio.get_running_loop()
+    prev_sighup = None
+    if hasattr(signal, "SIGHUP"):
+
+        def _on_sighup() -> None:
+            logger.info("SIGHUP received — terminal lost, exiting app")
+            app.exit(return_code=1, message="Terminal connection lost (SIGHUP)")
+
+        try:
+            prev_sighup = loop.add_signal_handler(signal.SIGHUP, _on_sighup)
+        except (NotImplementedError, OSError):
+            prev_sighup = None
+
     try:
         await app.run_async()
     finally:
+        if hasattr(signal, "SIGHUP"):
+            try:
+                loop.remove_signal_handler(signal.SIGHUP)
+            except (NotImplementedError, OSError):
+                pass
         # Guarantee server cleanup regardless of how the app exits.
         # Covers both the pre-started server_proc path and the deferred
         # server_kwargs path (where the background worker sets _server_proc).

--- a/src/handler/agent/tui/clipboard.py
+++ b/src/handler/agent/tui/clipboard.py
@@ -89,42 +89,41 @@ def copy_selection_to_clipboard(app: App) -> None:
 
     combined_text = "\n".join(selected_texts)
 
-    # Try multiple clipboard methods
-    # Prefer pyperclip/app clipboard first (works reliably on local machines)
-    # OSC 52 is last resort (for SSH/remote where native clipboard unavailable)
-    copy_methods = [app.copy_to_clipboard]
+    copied = False
 
     # Try pyperclip if available (preferred - uses pbcopy on macOS)
     try:
         import pyperclip
 
-        copy_methods.insert(0, pyperclip.copy)
+        pyperclip.copy(combined_text)
+        copied = True
     except ImportError:
         pass
+    except (OSError, RuntimeError, TypeError) as e:
+        logger.debug("Clipboard copy method pyperclip.copy failed: %s", e, exc_info=True)
 
-    # OSC 52 as fallback for remote/SSH sessions
-    copy_methods.append(_copy_osc52)
+    if not copied:
+        for copy_fn in (app.copy_to_clipboard, _copy_osc52):
+            try:
+                copy_fn(combined_text)
+                copied = True
+            except (OSError, RuntimeError, TypeError) as e:
+                logger.debug(
+                    "Clipboard copy method %s failed: %s",
+                    getattr(copy_fn, "__name__", repr(copy_fn)),
+                    e,
+                    exc_info=True,
+                )
 
-    for copy_fn in copy_methods:
-        try:
-            copy_fn(combined_text)
-            # Use markup=False to prevent copied text from being parsed as Rich markup
-            app.notify(
-                f'"{_shorten_preview(selected_texts)}" copied',
-                severity="information",
-                timeout=2,
-                markup=False,
-            )
-        except (OSError, RuntimeError, TypeError) as e:
-            logger.debug(
-                "Clipboard copy method %s failed: %s",
-                getattr(copy_fn, "__name__", repr(copy_fn)),
-                e,
-                exc_info=True,
-            )
-            continue
-        else:
-            return
+    if copied:
+        # Use markup=False to prevent copied text from being parsed as Rich markup
+        app.notify(
+            f'"{_shorten_preview(selected_texts)}" copied',
+            severity="information",
+            timeout=2,
+            markup=False,
+        )
+        return
 
     # If all methods fail, still notify but warn
     app.notify(

--- a/src/handler/agent/tui/command_registry.py
+++ b/src/handler/agent/tui/command_registry.py
@@ -124,6 +124,12 @@ COMMANDS: tuple[SlashCommand, ...] = (
         hidden_keywords="cost",
     ),
     SlashCommand(
+        name="/use",
+        description="Switch active obdiag cluster config",
+        bypass_tier=BypassTier.QUEUED,
+        hidden_keywords="cluster config obdiag",
+    ),
+    SlashCommand(
         name="/reload",
         description="Reload config from environment variables and .env",
         bypass_tier=BypassTier.QUEUED,

--- a/src/handler/agent/tui/tool_call_repair.py
+++ b/src/handler/agent/tui/tool_call_repair.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# Copyright (c) 2022 OceanBase
+# OceanBase Diagnostic Tool is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+# See the Mulan PSL v2 for more details.
+
+"""Middleware that repairs malformed JSON in LLM tool call arguments.
+
+Some LLMs (e.g. Qwen3) occasionally produce invalid JSON in function-call
+arguments — stray line-number prefixes, trailing commas, etc.  LangChain's
+``default_tool_parser`` moves these calls to ``AIMessage.invalid_tool_calls``
+and LangGraph's ``ToolNode`` never executes them, leaving the user with a
+confusing error.
+
+This middleware intercepts the model response, attempts lightweight JSON
+repair on each ``invalid_tool_call``, and promotes successfully repaired
+calls back to ``tool_calls`` so the graph can execute them normally.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    ModelRequest,
+    ModelResponse,
+)
+from langchain_core.messages import AIMessage
+from langchain_core.messages.tool import tool_call
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+_LINE_NUMBER_RE = re.compile(r"^(\s*)\d+\s+", re.MULTILINE)
+_TRAILING_COMMA_RE = re.compile(r",\s*([}\]])")
+
+
+def _try_repair_json(raw: str) -> dict[str, Any] | None:
+    """Attempt to repair common LLM JSON errors and parse the result.
+
+    Returns the parsed dict on success, or ``None`` if repair fails.
+    """
+    # Strategy 1: strip line-number prefixes (e.g. "  9    " at line start)
+    cleaned = _LINE_NUMBER_RE.sub(r"\1", raw)
+    # Strategy 2: remove trailing commas before } or ]
+    cleaned = _TRAILING_COMMA_RE.sub(r"\1", cleaned)
+
+    try:
+        result = json.loads(cleaned)
+        if isinstance(result, dict):
+            return result
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    return None
+
+
+def _repair_response(response: ModelResponse) -> ModelResponse:
+    """Inspect the response for invalid tool calls and attempt repair."""
+    if not response.result:
+        return response
+
+    msg = response.result[0]
+    if not isinstance(msg, AIMessage):
+        return response
+
+    invalid_calls = msg.invalid_tool_calls
+    if not invalid_calls:
+        return response
+
+    repaired_tool_calls = list(msg.tool_calls)
+    still_invalid = []
+
+    for itc in invalid_calls:
+        raw_args = itc.get("args")
+        if not isinstance(raw_args, str) or not raw_args.strip():
+            still_invalid.append(itc)
+            continue
+
+        parsed = _try_repair_json(raw_args)
+        if parsed is not None:
+            logger.info("Repaired invalid tool call '%s' (id=%s)", itc.get("name"), itc.get("id"))
+            repaired_tool_calls.append(tool_call(name=itc.get("name") or "", args=parsed, id=itc.get("id")))
+        else:
+            logger.warning("Could not repair invalid tool call '%s' (id=%s): %s", itc.get("name"), itc.get("id"), raw_args[:200])
+            still_invalid.append(itc)
+
+    if len(still_invalid) == len(invalid_calls):
+        return response
+
+    repaired_msg = msg.model_copy(update={"tool_calls": repaired_tool_calls, "invalid_tool_calls": still_invalid})
+    return ModelResponse(result=[repaired_msg, *response.result[1:]], structured_response=response.structured_response)
+
+
+class ToolCallRepairMiddleware(AgentMiddleware):
+    """Repair malformed JSON in ``invalid_tool_calls`` before the graph sees them."""
+
+    def wrap_model_call(self, request: ModelRequest, handler: Callable[[ModelRequest], ModelResponse]) -> ModelResponse:
+        return _repair_response(handler(request))
+
+    async def awrap_model_call(self, request: ModelRequest, handler: Callable[[ModelRequest], Awaitable[ModelResponse]]) -> ModelResponse:
+        return _repair_response(await handler(request))

--- a/src/handler/agent/tui/tool_display.py
+++ b/src/handler/agent/tui/tool_display.py
@@ -24,6 +24,9 @@ _HIDDEN_CHAR_MARKER = " [hidden chars removed]"
 """Marker appended to display values that had dangerous Unicode stripped, so
 users know the value was modified for safety."""
 
+_SENSITIVE_ARG_KEYWORDS = ("password", "secret", "token", "api_key", "apikey", "credential")
+"""Substrings that, when found in an argument name (case-insensitive), indicate the value should be masked in display output."""
+
 
 def _format_timeout(seconds: int) -> str:
     """Format timeout in human-readable units (e.g., 300 -> '5m', 3600 -> '1h').
@@ -235,8 +238,15 @@ def format_tool_display(tool_name: str, tool_args: dict) -> str:
             return f"{prefix} {tool_name}({count} items)"
 
     # Fallback: generic formatting for unknown tools
-    # Show all arguments in key=value format
-    args_str = ", ".join(f"{_sanitize_display_value(k, max_length=30)}=" f"{_sanitize_display_value(v, max_length=50)}" for k, v in tool_args.items())
+    # Show all arguments in key=value format; mask sensitive values (passwords, tokens, etc.)
+    parts = []
+    for k, v in tool_args.items():
+        k_display = _sanitize_display_value(k, max_length=30)
+        if any(s in str(k).lower() for s in _SENSITIVE_ARG_KEYWORDS):
+            parts.append(f"{k_display}=***")
+        else:
+            parts.append(f"{k_display}={_sanitize_display_value(v, max_length=50)}")
+    args_str = ", ".join(parts)
     return f"{prefix} {tool_name}({args_str})"
 
 

--- a/src/handler/agent/tui/widgets/tool_widgets.py
+++ b/src/handler/agent/tui/widgets/tool_widgets.py
@@ -108,19 +108,25 @@ class ToolApprovalWidget(Vertical):
 class GenericApprovalWidget(ToolApprovalWidget):
     """Generic approval widget for unknown tools."""
 
+    _SENSITIVE_KEYWORDS = ("password", "secret", "token", "api_key", "apikey", "credential")
+
     def compose(self) -> ComposeResult:
         """Compose the generic tool display.
 
         Yields:
             Static widgets displaying each key-value pair from tool data.
+            Sensitive values (passwords, tokens, etc.) are masked.
         """
         for key, value in self.data.items():
             if value is None:
                 continue
-            value_str = str(value)
-            if len(value_str) > _MAX_VALUE_LEN:
-                hidden = len(value_str) - _MAX_VALUE_LEN
-                value_str = value_str[:_MAX_VALUE_LEN] + f"... ({hidden} more chars)"
+            if any(s in str(key).lower() for s in self._SENSITIVE_KEYWORDS):
+                value_str = "***"
+            else:
+                value_str = str(value)
+                if len(value_str) > _MAX_VALUE_LEN:
+                    hidden = len(value_str) - _MAX_VALUE_LEN
+                    value_str = value_str[:_MAX_VALUE_LEN] + f"... ({hidden} more chars)"
             yield Static(f"{key}: {value_str}", markup=False, classes="approval-description")
 
 

--- a/src/handler/agent/tui/widgets/welcome.py
+++ b/src/handler/agent/tui/widgets/welcome.py
@@ -330,5 +330,6 @@ def build_welcome_footer(*, primary_color: str = theme.PRIMARY, tip: str | None 
         tip = random.choice(_TIPS)  # noqa: S311
     return Content.assemble(
         ("\nReady! Describe your OceanBase issue or ask for diagnostics.\n", primary_color),
+        ("Use /threads to resume a previous session. ", "dim"),
         (f"Tip: {tip}", "dim italic"),
     )


### PR DESCRIPTION
## Motivation
Briefly describe the problem or user need (e.g. non-interactive agent runs, pipe-friendly output, thread resume, absolute paths for configs/logs/outputs, tool-call display/repair in the TUI, etc.).

## Summary of changes
- **CLI**: Update `obdiag agent` non-interactive flags (e.g. `-n`, `-q`, `--no-stream`) and resume behavior (`-r` / `-r <thread_id>`)—keep this list aligned with the actual options in `diag_cmd.py`.
- **Paths**: Normalize obdiag workspace / `~/.obdiag`-related paths to absolute paths to avoid ambiguous relative paths.
- **DB connector**: Provide a silent stdio fallback when no context is supplied, avoiding null-context issues in `OBConnector`.
- **TUI**: Improvements to welcome screen, command registry, clipboard, tool rendering, and **tool call repair** (new module), plus related UX fixes.
- **Agent prompts & toolsets**: Align system guidance and tool behavior for cluster switching, path conventions, and one-off diagnostics on other clusters.
- **Repo hygiene**: Extend `.gitignore` for local/tooling directories (list the main entries you added).
