### PR TITLE
Fix duplicated table stats in observer base gather

### DIFF
--- a/plugins/gather/tasks/observer/base.yaml
+++ b/plugins/gather/tasks/observer/base.yaml
@@ -58,7 +58,7 @@ task:
         sql: "SELECT a.TENANT_NAME,a.TENANT_ID,b.SVR_IP FROM oceanbase.DBA_OB_TENANTS a, oceanbase.GV$OB_UNITS b WHERE a.TENANT_ID=b.TENANT_ID;"
         global: true
       - type: sql
-        sql: "select /*+read_consistency(weak) QUERY_TIMEOUT(60000000) */  t1.svr_ip, t1.role, t1.tenant_id,t1.database_name,t1.table_name, ifnull(t2.data_size,0) / 1073741824 as total_data_size_gb  from (select tenant_id, database_name, table_name, role, svr_ip, table_id, tablet_id  from oceanbase.cdb_ob_table_locations) t1 left join  (select tenant_id, tablet_id, data_size from oceanbase.cdb_ob_tablet_replicas)  t2 on t1.tenant_id = t2.tenant_id and  t1.tablet_id = t2.tablet_id order by total_data_size_gb desc limit 50;"
+        sql: "select /*+read_consistency(weak) QUERY_TIMEOUT(60000000) */ t1.tenant_id, t1.database_name, t1.table_name, sum(ifnull(t2.data_size,0)) / 1073741824 as total_data_size_gb from (select tenant_id, database_name, table_name, role, svr_ip, ls_id, tablet_id from oceanbase.cdb_ob_table_locations where role='leader') t1 left join (select tenant_id, svr_ip, ls_id, tablet_id, data_size from oceanbase.cdb_ob_tablet_replicas) t2 on t1.tenant_id = t2.tenant_id and t1.svr_ip = t2.svr_ip and t1.ls_id = t2.ls_id and t1.tablet_id = t2.tablet_id group by t1.tenant_id, t1.database_name, t1.table_name order by total_data_size_gb desc limit 50;"
         global: true
       - type: sql
         sql: "show parameters"

--- a/test/gather/test_observer_base_yaml.py
+++ b/test/gather/test_observer_base_yaml.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# Copyright (c) 2022 OceanBase
+# OceanBase Diagnostic Tool is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+# See the Mulan PSL v2 for more details.
+
+import unittest
+
+from src.common.tool import YamlUtils
+
+
+OBSERVER_BASE_TASK = "plugins/gather/tasks/observer/base.yaml"
+
+
+class TestObserverBaseYaml(unittest.TestCase):
+    def test_table_size_sql_aggregates_leader_tablets_by_table(self):
+        task_data = YamlUtils.read_yaml_data(OBSERVER_BASE_TASK)
+        steps = next(item["steps"] for item in task_data["task"] if item["version"] == "[4.0.0.0, *]")
+        table_size_sql = next(step["sql"] for step in steps if "total_data_size_gb" in step.get("sql", ""))
+        normalized_sql = " ".join(table_size_sql.lower().split())
+
+        self.assertIn("where role='leader'", normalized_sql)
+        self.assertIn("sum(ifnull(t2.data_size,0)) / 1073741824 as total_data_size_gb", normalized_sql)
+        self.assertIn("t1.svr_ip = t2.svr_ip", normalized_sql)
+        self.assertIn("t1.ls_id = t2.ls_id", normalized_sql)
+        self.assertIn("t1.tablet_id = t2.tablet_id", normalized_sql)
+        self.assertIn("group by t1.tenant_id, t1.database_name, t1.table_name", normalized_sql)
+
+        self.assertNotIn("t1.svr_ip, t1.role", normalized_sql)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #387.

`observer.base` gathered table size information with a join on only `tenant_id` and `tablet_id`. On OceanBase 4.x, the same tablet can have multiple replica rows, so this could cross-match replicas and show many rows for the same table.

This PR changes the query to:

- collect only leader table locations
- join tablet replicas by `tenant_id`, `svr_ip`, `ls_id`, and `tablet_id`
- aggregate `data_size` by `tenant_id`, `database_name`, and `table_name`

The result is one table-size row per table instead of repeated rows for the same table.

## Verification

```bash
PYTHONPATH=. python -m pytest test/gather/test_observer_base_yaml.py -q
PYTHONPATH=. python -m pytest test/common/test_scene.py -q
black --check -S -l 256 test/gather/test_observer_base_yaml.py
PYTHONPATH=. python -m pytest test/gather/test_observer_base_yaml.py test/common/test_scene.py -q
```

Results:

- `test_observer_base_yaml.py`: 1 passed
- `test_scene.py`: 17 passed
- combined: 18 passed
- black check: passed

