### PR TITLE
Collect compaction_low_thread_score in compaction diagnostics

### DIFF
--- a/plugins/gather/tasks/observer/compaction.yaml
+++ b/plugins/gather/tasks/observer/compaction.yaml
@@ -145,6 +145,9 @@ task:
         sql: "show parameters like 'freeze_trigger_percentage';"
         global: true
       - type: sql
+        sql: "select tenant_id, zone, svr_ip, svr_port, name, value, info, section, scope, edit_level from oceanbase.__all_virtual_tenant_parameter_info where name = 'compaction_low_thread_score' order by tenant_id, zone, svr_ip, svr_port;"
+        global: true
+      - type: sql
         sql: "select t.tenant_name, t1.database_name, round(sum(t2.data_size)/1024/1024/1024,2) as data_size_gb, round(sum(t2.required_size)/1024/1024/1024,2) as required_size_gb from oceanbase.dba_ob_tenants t, oceanbase.cdb_ob_table_locations t1, oceanbase.cdb_ob_tablet_replicas t2 where t.tenant_id=t1.tenant_id and t1.svr_ip=t2.svr_ip and t1.tenant_id=t2.tenant_id and t1.ls_id=t2.ls_id and t1.tablet_id=t2.tablet_id and t1.role='leader' group by t.tenant_name, t1.database_name order by data_size_gb desc;"
         global: true
       - type: sql

--- a/plugins/rca/major_hold.py
+++ b/plugins/rca/major_hold.py
@@ -147,6 +147,12 @@ class MajorHoldScene(RcaScene):
         err_tenant_ids = []
         self.record.add_record("Starting major compaction hold diagnosis...")
 
+        try:
+            self.record.add_record("Step 0: Checking compaction_low_thread_score for all tenants")
+            self._check_compaction_low_thread_score(self.record)
+        except Exception as e:
+            self.stdio.warn("Error checking compaction_low_thread_score: {0}".format(e))
+
         # Step 1: Check for compaction errors (IS_ERROR='YES')
         try:
             self.record.add_record("Step 1: Checking CDB_OB_MAJOR_COMPACTION for errors")
@@ -285,6 +291,24 @@ class MajorHoldScene(RcaScene):
                     # Alert if speed is very low
                     if speed_mbps < 1 and elapsed > 600:  # < 1MB/s after 10 minutes
                         self.record.add_suggest("Very slow compaction detected for tenant {0} ({1:.2f} MB/s). " "Check disk I/O, memory pressure, or DAG scheduler status.".format(tenant_id, speed_mbps))
+
+    def _check_compaction_low_thread_score(self, record):
+        sql = """
+            SELECT tenant_id, zone, svr_ip, svr_port, name, value, info, section, scope, edit_level
+            FROM oceanbase.__all_virtual_tenant_parameter_info
+            WHERE name = 'compaction_low_thread_score'
+            ORDER BY tenant_id, zone, svr_ip, svr_port;
+        """
+        parameter_data = self._execute_sql_safe(sql, "check compaction_low_thread_score")
+        if not parameter_data:
+            record.add_record("No compaction_low_thread_score parameter data found")
+            return
+
+        self._save_to_file("compaction_low_thread_score.json", parameter_data)
+        record.add_record("Collected compaction_low_thread_score for {0} tenant/server scope rows".format(len(parameter_data)))
+        zero_value_rows = [row for row in parameter_data if str(row.get("value", "")).strip() == "0"]
+        if zero_value_rows:
+            record.add_record("compaction_low_thread_score value 0 means OceanBase uses the internal default thread score")
 
     def _diagnose_tenant(self, err_tenant_id):
         """

--- a/test/rca/test_major_hold_compaction_thread_score.py
+++ b/test/rca/test_major_hold_compaction_thread_score.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# Copyright (c) 2022 OceanBase
+# OceanBase Diagnostic Tool is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+# See the Mulan PSL v2 for more details.
+
+import unittest
+from unittest.mock import MagicMock
+
+from plugins.rca.major_hold import MajorHoldScene
+from src.common.tool import YamlUtils
+
+
+class TestMajorHoldCompactionThreadScore(unittest.TestCase):
+
+    def test_gather_compaction_collects_low_thread_score_for_all_tenants(self):
+        task_data = YamlUtils.read_yaml_data("plugins/gather/tasks/observer/compaction.yaml")
+        steps = next(item["steps"] for item in task_data["task"] if item["version"] == "[4.0.0.0, *]")
+        sql_list = [step["sql"].lower() for step in steps if step.get("type") == "sql"]
+        parameter_sql = next(sql for sql in sql_list if "compaction_low_thread_score" in sql)
+
+        self.assertIn("__all_virtual_tenant_parameter_info", parameter_sql)
+        self.assertIn("tenant_id", parameter_sql)
+        self.assertIn("order by tenant_id, zone, svr_ip, svr_port", parameter_sql)
+
+    def test_major_hold_records_low_thread_score(self):
+        scene = MajorHoldScene()
+        scene._execute_sql_safe = MagicMock(
+            return_value=[
+                {
+                    "tenant_id": 1001,
+                    "zone": "zone1",
+                    "svr_ip": "127.0.0.1",
+                    "svr_port": 2882,
+                    "name": "compaction_low_thread_score",
+                    "value": "0",
+                }
+            ]
+        )
+        scene._save_to_file = MagicMock()
+        record = MagicMock()
+
+        scene._check_compaction_low_thread_score(record)
+
+        scene._execute_sql_safe.assert_called_once()
+        self.assertIn("compaction_low_thread_score", scene._execute_sql_safe.call_args[0][0])
+        scene._save_to_file.assert_called_once()
+        record.add_record.assert_any_call("Collected compaction_low_thread_score for 1 tenant/server scope rows")
+        record.add_record.assert_any_call("compaction_low_thread_score value 0 means OceanBase uses the internal default thread score")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #1237.

Adds `compaction_low_thread_score` collection to both compaction diagnostics paths:

- `observer.compaction` gather now collects the parameter from `oceanbase.__all_virtual_tenant_parameter_info`, ordered by tenant and server scope, so all tenant/server values are included.
- `rca major_hold` now records and saves `compaction_low_thread_score` at the start of the diagnosis.

The RCA records value `0` as OceanBase using the internal default thread score instead of treating it as an error.

## Verification

```bash
PYTHONPATH=. python -m pytest test/rca/test_major_hold_compaction_thread_score.py -q
black --check -S -l 256 plugins/rca/major_hold.py test/rca/test_major_hold_compaction_thread_score.py
PYTHONPATH=. python -m pytest test/common/test_scene.py -q
PYTHONPATH=. python -m pytest test/rca/test_major_hold_compaction_thread_score.py test/common/test_scene.py -q
git diff --check
```

Results:

- `test_major_hold_compaction_thread_score.py`: 2 passed
- black check: passed
- `test_scene.py`: 17 passed
- combined: 19 passed
- diff check: passed

