### PR TITLE
Add SQL review for OR function predicates

### DIFF
--- a/src/handler/analyzer/sql/rule_manager.py
+++ b/src/handler/analyzer/sql/rule_manager.py
@@ -22,6 +22,7 @@ from src.handler.analyzer.sql.rules.abstract_rule import AbstractRule
 from src.handler.analyzer.sql.rules.result import Result
 from src.handler.analyzer.sql.rules.review.arithmetic import ArithmeticRule
 from src.handler.analyzer.sql.rules.review.full_scan import FullScanRule
+from src.handler.analyzer.sql.rules.review.function_index_or_predicate import FunctionIndexOrPredicateRule
 from src.handler.analyzer.sql.rules.review.is_null import IsNullRule
 from src.handler.analyzer.sql.rules.review.large_in_clause import LargeInClauseAdjustedRule
 from src.handler.analyzer.sql.rules.review.multi_table_join import MultiTableJoinRule
@@ -78,6 +79,7 @@ class SQLReviewRuleManager(object):
         self.manager = RuleManager()
         self.manager.register_rule(SelectAllRule)
         self.manager.register_rule(ArithmeticRule)
+        self.manager.register_rule(FunctionIndexOrPredicateRule)
         self.manager.register_rule(FullScanRule)
         self.manager.register_rule(IsNullRule)
         self.manager.register_rule(LargeInClauseAdjustedRule)

--- a/src/handler/analyzer/sql/rules/review/function_index_or_predicate.py
+++ b/src/handler/analyzer/sql/rules/review/function_index_or_predicate.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# Copyright (c) 2022 OceanBase
+# OceanBase Diagnostic Tool is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+# See the Mulan PSL v2 for more details.
+
+"""
+@time: 2026/6/8
+@file: function_index_or_predicate.py
+@desc:
+"""
+
+from sqlgpt_parser.parser.tree.expression import FunctionCall, LogicalBinaryExpression
+from sqlgpt_parser.parser.tree.statement import Statement
+from sqlgpt_parser.parser.tree.visitor import DefaultTraversalVisitor
+from src.handler.analyzer.sql.rules.abstract_rule import AbstractRule
+from src.handler.analyzer.sql.rules.level import Level
+from src.handler.analyzer.sql.rules.result import Result
+
+
+class FunctionIndexOrPredicateRule(AbstractRule):
+    rule_name = "function_index_or_predicate_rule"
+    rule_description = """
+        OceanBase may fail to infer function indexes for OR-connected function predicates.
+        """
+
+    def match(self, root: Statement, catalog=None) -> bool:
+        class FunctionCallVisitor(DefaultTraversalVisitor):
+            def __init__(self):
+                self.match = False
+
+            def visit_function_call(self, node, context):
+                self.match = True
+                return None
+
+        class OrPredicateVisitor(DefaultTraversalVisitor):
+            def __init__(self):
+                self.match = False
+
+            @staticmethod
+            def _has_function_call(node):
+                if isinstance(node, FunctionCall):
+                    return True
+                visitor = FunctionCallVisitor()
+                visitor.process(node, None)
+                return visitor.match
+
+            def visit_logical_binary_expression(self, node, context):
+                if isinstance(node, LogicalBinaryExpression) and node.type == 'OR':
+                    if self._has_function_call(node.left) or self._has_function_call(node.right):
+                        self.match = True
+                        return None
+                self.process(node.left, context)
+                self.process(node.right, context)
+                return None
+
+        try:
+            visitor = OrPredicateVisitor()
+            visitor.process(root, None)
+            return visitor.match
+        except Exception:
+            return False
+
+    def suggestion(self, root: Statement, catalog=None):
+        if self.match(root, catalog):
+            suggestion_text = (
+                "Detected OR-connected function predicates. OceanBase may not infer function indexes for this pattern; " "consider rewriting the OR branches as UNION ALL, or use the generated hidden column that backs the function index when appropriate."
+            )
+            return Result(self.rule_name, Level.NOTICE, suggestion_text, self.rule_description)
+        return Result(self.rule_name, Level.OK, "No OR-connected function predicates detected.", self.rule_description)

--- a/test/analyzer/sql/test_function_index_or_predicate_rule.py
+++ b/test/analyzer/sql/test_function_index_or_predicate_rule.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# Copyright (c) 2022 OceanBase
+# OceanBase Diagnostic Tool is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of the Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+# See the Mulan PSL v2 for more details.
+
+"""
+@time: 2026/6/8
+@file: test_function_index_or_predicate_rule.py
+@desc:
+"""
+
+import unittest
+
+from sqlgpt_parser.parser.oceanbase_parser import parser
+from src.handler.analyzer.sql.rule_manager import SQLReviewRuleManager
+from src.handler.analyzer.sql.rules.level import Level
+from src.handler.analyzer.sql.rules.review.function_index_or_predicate import FunctionIndexOrPredicateRule
+
+
+class TestFunctionIndexOrPredicateRule(unittest.TestCase):
+    def setUp(self):
+        self.rule = FunctionIndexOrPredicateRule()
+
+    def test_or_connected_function_predicates_detected(self):
+        sql = "SELECT count(*) FROM cross_record WHERE RIGHT(tx_sender, 13) = 'xxx' OR RIGHT(tx_receiver, 13) = 'xxx'"
+        parsed_stmt = parser.parse(sql)
+        self.assertTrue(self.rule.match(parsed_stmt))
+
+    def test_and_connected_function_predicates_not_detected(self):
+        sql = "SELECT count(*) FROM cross_record WHERE RIGHT(tx_sender, 13) = 'xxx' AND RIGHT(tx_receiver, 13) = 'xxx'"
+        parsed_stmt = parser.parse(sql)
+        self.assertFalse(self.rule.match(parsed_stmt))
+
+    def test_plain_or_predicates_not_detected(self):
+        sql = "SELECT * FROM cross_record WHERE tx_sender = 'xxx' OR tx_receiver = 'xxx'"
+        parsed_stmt = parser.parse(sql)
+        self.assertFalse(self.rule.match(parsed_stmt))
+
+    def test_suggestion_level_for_or_connected_function_predicates(self):
+        sql = "SELECT count(*) FROM cross_record WHERE RIGHT(tx_sender, 13) = 'xxx' OR RIGHT(tx_receiver, 13) = 'xxx'"
+        parsed_stmt = parser.parse(sql)
+        result = self.rule.suggestion(parsed_stmt)
+        self.assertEqual(result.level, Level.NOTICE)
+
+    def test_rule_registered_in_sql_review_manager(self):
+        registered_rules = SQLReviewRuleManager().manager._registered_rules
+        self.assertIn(FunctionIndexOrPredicateRule.rule_name, registered_rules)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a SQL review rule for OR-connected function predicates, such as `RIGHT(col, 13) = value OR RIGHT(other_col, 13) = value`.
- Register the rule in SQLReviewRuleManager so SQL diagnosis can suggest function-index-aware rewrites.
- Add regression tests for the issue #339 pattern, AND predicates, plain OR predicates, suggestion level, and rule registration.

Fixes #339

## Verification
- `PYTHONPATH=. python -m pytest test/analyzer/sql/test_function_index_or_predicate_rule.py -q`
- `PYTHONPATH=. python -m pytest test/analyzer/sql -q`
- `PYTHONPATH=. python -m unittest discover -s test/analyzer/sql -p 'test_*.py'`
- `black --check -S -l 256 src/handler/analyzer/sql/rules/review/function_index_or_predicate.py src/handler/analyzer/sql/rule_manager.py test/analyzer/sql/test_function_index_or_predicate_rule.py`
- `python workflow_data/check_py_files.py .`
- `git diff --check`
