### PR TITLE
Expose plan monitor report paths

### DIFF
--- a/src/handler/gather/gather_plan_monitor.py
+++ b/src/handler/gather/gather_plan_monitor.py
@@ -265,10 +265,21 @@ class GatherPlanMonitorHandler(object):
         self.stdio.verbose("[sql plan monitor report task] end")
         summary_tuples = self.__get_overall_summary(gather_tuples)
         self.stdio.print(summary_tuples)
+        self.stdio.print("SQL plan monitor report file: {0}".format(self.report_file_path))
+        self.stdio.print("SQL plan monitor resources directory: {0}".format(target_resources_path))
         # 将汇总结果持久化记录到文件中
         FileUtil.write_append(os.path.join(pack_dir_this_command, "result_summary.txt"), summary_tuples)
         # return gather_tuples, gather_pack_path_dict
-        return ObdiagResult(ObdiagResult.SUCCESS_CODE, data={"store_dir": pack_dir_this_command})
+        return ObdiagResult(ObdiagResult.SUCCESS_CODE, data=self._build_result_data(pack_dir_this_command, target_resources_path))
+
+    def _build_result_data(self, store_dir, resources_dir=None):
+        if resources_dir is None:
+            resources_dir = os.path.join(store_dir, "resources")
+        return {
+            "store_dir": store_dir,
+            "report_file": self.report_file_path,
+            "resources_dir": resources_dir,
+        }
 
     def __init_db_conn(self, env):
         try:

--- a/test/gather/test_gather_plan_monitor.py
+++ b/test/gather/test_gather_plan_monitor.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# Copyright (c) 2022 OceanBase
+# OceanBase Diagnostic Tool is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+# See the Mulan PSL v2 for more details.
+
+"""
+@time: 2026/6/8
+@file: test_gather_plan_monitor.py
+@desc: Unit tests for gather_plan_monitor result paths.
+"""
+
+import os
+import unittest
+from unittest.mock import MagicMock
+
+from src.handler.gather.gather_plan_monitor import GatherPlanMonitorHandler
+
+
+class TestGatherPlanMonitorResultPaths(unittest.TestCase):
+    def test_build_result_data_includes_report_and_resources_paths(self):
+        context = MagicMock()
+        context.stdio = MagicMock()
+        context.get_variable.return_value = None
+        handler = GatherPlanMonitorHandler(context)
+        handler.report_file_path = "/tmp/pack/sql_plan_monitor_report.html"
+
+        data = handler._build_result_data("/tmp/pack")
+
+        self.assertEqual(data["store_dir"], "/tmp/pack")
+        self.assertEqual(data["report_file"], "/tmp/pack/sql_plan_monitor_report.html")
+        self.assertEqual(data["resources_dir"], os.path.join("/tmp/pack", "resources"))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- print the generated SQL plan monitor HTML report path and resources directory
- return `report_file` and `resources_dir` in the gather result data alongside `store_dir`
- add unit coverage for the result path payload

Fixes #1011

## Verification
- `PYTHONPATH=. python -m pytest test/gather/test_gather_plan_monitor.py test/common/test_scene.py -q`
- `black --check -S -l 256 src/handler/gather/gather_plan_monitor.py test/gather/test_gather_plan_monitor.py`
- `python workflow_data/check_py_files.py .`
- `git diff --check`