### PR TITLE
Handle prepared-statement placeholders in plan monitor

### DIFF
--- a/src/common/tool.py
+++ b/src/common/tool.py
@@ -1541,48 +1541,16 @@ class StringUtils(object):
             return sql
 
         try:
-            # Parse parameters
-            params = []
-            current_param = ""
-            in_quotes = False
-            quote_char = None
-
-            for char in params_value:
-                if char in ["'", '"']:
-                    if not in_quotes:
-                        in_quotes = True
-                        quote_char = char
-                        current_param += char
-                    elif char == quote_char:
-                        in_quotes = False
-                        quote_char = None
-                        current_param += char
-                    else:
-                        current_param += char
-                elif char == ',' and not in_quotes:
-                    # Remove leading/trailing spaces
-                    param = current_param.strip()
-                    params.append(param)
-                    current_param = ""
-                else:
-                    current_param += char
-
-            # Process the last parameter
-            if current_param:
-                param = current_param.strip()
-                params.append(param)
-
-            # Replace placeholders in SQL
+            params = StringUtils._split_sql_params(params_value)
             result_sql = sql
             for param in params:
-                # Find the first ? and replace
-                pos = result_sql.find('?')
-                if pos != -1:
-                    result_sql = result_sql[:pos] + str(param) + result_sql[pos + 1 :]
-                else:
-                    # If the parameter count does not match, record a warning and stop
-                    stdio.warn(f"Parameter count mismatch: SQL has more placeholders than parameters. SQL: {sql}, Params: {params_value}")
+                pos = StringUtils._find_next_sql_placeholder(result_sql)
+                if pos == -1:
+                    stdio.warn(f"Parameter count mismatch: SQL has fewer placeholders than parameters. SQL: {sql}, Params: {params_value}")
                     break
+                result_sql = result_sql[:pos] + str(param) + result_sql[pos + 1 :]
+            if StringUtils.has_sql_placeholder(result_sql):
+                stdio.warn(f"Parameter count mismatch: SQL has more placeholders than parameters. SQL: {sql}, Params: {params_value}")
 
             stdio.verbose(f"Original SQL: {sql}")
             stdio.verbose(f"Params: {params_value}")
@@ -1593,6 +1561,91 @@ class StringUtils(object):
         except Exception as e:
             stdio.warn(f"Failed to fill SQL with parameters: {e}")
             return sql
+
+    @staticmethod
+    def _split_sql_params(params_value):
+        params = []
+        current_param = ""
+        in_quotes = False
+        quote_char = None
+        escape_next = False
+
+        for char in params_value:
+            if escape_next:
+                current_param += char
+                escape_next = False
+                continue
+            if char == "\\":
+                current_param += char
+                escape_next = True
+                continue
+            if char in ["'", '"']:
+                if not in_quotes:
+                    in_quotes = True
+                    quote_char = char
+                elif char == quote_char:
+                    in_quotes = False
+                    quote_char = None
+                current_param += char
+            elif char == ',' and not in_quotes:
+                params.append(current_param.strip())
+                current_param = ""
+            else:
+                current_param += char
+
+        if current_param:
+            params.append(current_param.strip())
+        return params
+
+    @staticmethod
+    def has_sql_placeholder(sql):
+        return StringUtils._find_next_sql_placeholder(sql) != -1
+
+    @staticmethod
+    def _find_next_sql_placeholder(sql):
+        if not sql:
+            return -1
+
+        i = 0
+        length = len(sql)
+        quote_char = None
+        while i < length:
+            char = sql[i]
+            next_char = sql[i + 1] if i + 1 < length else ""
+
+            if quote_char:
+                if char == "\\":
+                    i += 2
+                    continue
+                if char == quote_char:
+                    if quote_char == "'" and next_char == "'":
+                        i += 2
+                        continue
+                    quote_char = None
+                i += 1
+                continue
+
+            if char in ("'", '"', "`"):
+                quote_char = char
+                i += 1
+                continue
+            if char == "-" and next_char == "-":
+                newline = sql.find("\n", i + 2)
+                if newline == -1:
+                    return -1
+                i = newline + 1
+                continue
+            if char == "/" and next_char == "*":
+                end = sql.find("*/", i + 2)
+                if end == -1:
+                    return -1
+                i = end + 2
+                continue
+            if char == "?":
+                return i
+            i += 1
+
+        return -1
 
 
 class Cursor(SafeStdio):

--- a/src/handler/gather/gather_plan_monitor.py
+++ b/src/handler/gather/gather_plan_monitor.py
@@ -1187,6 +1187,8 @@ class GatherPlanMonitorHandler(object):
             return False
         if len(raw_sql) > 1000 and (ctrl / float(len(raw_sql))) > 0.001:
             return False
+        if StringUtils.has_sql_placeholder(raw_sql):
+            return False
         # Long INSERT from audit frequently embeds blob/hex; EXPLAIN usually fails even under length cap
         lead = raw_sql.lstrip()
         if len(lead) >= 6 and lead[:6].upper() == "INSERT" and len(raw_sql) > 8192:
@@ -1196,7 +1198,7 @@ class GatherPlanMonitorHandler(object):
     def report_plan_explain(self, db_name, raw_sql):
         if not self._sql_eligible_for_explain_extended(raw_sql):
             self.stdio.warn("skip EXPLAIN extended: query_sql is not eligible (empty, too long, null/replacement chars, " "high control-char ratio, or long INSERT; common with binary/blob). len=%s" % (len(raw_sql) if raw_sql else 0))
-            self.__report("<pre>EXPLAIN extended skipped: query_sql not suitable for text EXPLAIN " "(e.g. INSERT with large binary / blob in sql_audit).</pre>")
+            self.__report("<pre>EXPLAIN extended skipped: query_sql not suitable for text EXPLAIN " "(e.g. prepared statement placeholders, INSERT with large binary / blob in sql_audit).</pre>")
             return
         explain_sql = "explain extended %s" % raw_sql
         try:

--- a/test/common/test_fill_sql_with_params.py
+++ b/test/common/test_fill_sql_with_params.py
@@ -81,6 +81,24 @@ class TestFillSQLWithParams(unittest.TestCase):
         expected = "SELECT * FROM users WHERE id = 100 AND name = ?"
         self.assertEqual(result, expected)
 
+    def test_question_mark_in_string_literal_is_not_placeholder(self):
+        sql = "SELECT * FROM users WHERE remark = '?' AND id = ?"
+        params = "100"
+        result = self.string_utils.fill_sql_with_params(sql, params, self.string_utils.stdio)
+        expected = "SELECT * FROM users WHERE remark = '?' AND id = 100"
+        self.assertEqual(result, expected)
+
+    def test_question_mark_in_comments_is_not_placeholder(self):
+        sql = "SELECT /* ? */ * FROM users WHERE id = ? -- ?\nAND name = ?"
+        params = "100, 'Alice'"
+        result = self.string_utils.fill_sql_with_params(sql, params, self.string_utils.stdio)
+        expected = "SELECT /* ? */ * FROM users WHERE id = 100 -- ?\nAND name = 'Alice'"
+        self.assertEqual(result, expected)
+
+    def test_has_sql_placeholder_ignores_literals_and_comments(self):
+        self.assertFalse(self.string_utils.has_sql_placeholder("SELECT '?' /* ? */ -- ?\n"))
+        self.assertTrue(self.string_utils.has_sql_placeholder("SELECT * FROM users WHERE id = ?"))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/gather/test_gather_plan_monitor_ps_sql.py
+++ b/test/gather/test_gather_plan_monitor_ps_sql.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# Copyright (c) 2022 OceanBase
+# OceanBase Diagnostic Tool is licensed under Mulan PSL v2.
+# You can use this software according to the terms and conditions of Mulan PSL v2.
+# You may obtain a copy of Mulan PSL v2 at:
+#          http://license.coscl.org.cn/MulanPSL2
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+# EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+# MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+# See the Mulan PSL v2 for more details.
+
+"""
+@time: 2026/6/8
+@file: test_gather_plan_monitor_ps_sql.py
+@desc: Unit tests for prepared-statement SQL handling in plan monitor.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from src.handler.gather.gather_plan_monitor import GatherPlanMonitorHandler
+
+
+class TestGatherPlanMonitorPreparedStatementSQL(unittest.TestCase):
+    def setUp(self):
+        context = MagicMock()
+        context.stdio = MagicMock()
+        context.get_variable.return_value = None
+        self.handler = GatherPlanMonitorHandler(context)
+
+    def test_unfilled_ps_placeholder_is_not_eligible_for_explain(self):
+        sql = "SELECT * FROM users WHERE id = ?"
+        self.assertFalse(self.handler._sql_eligible_for_explain_extended(sql))
+
+    def test_question_mark_literal_is_eligible_for_explain(self):
+        sql = "SELECT * FROM users WHERE remark = '?'"
+        self.assertTrue(self.handler._sql_eligible_for_explain_extended(sql))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- make prepared-statement parameter filling skip `?` inside strings, quoted identifiers, and comments
- skip `EXPLAIN extended` when SQL audit text still contains unfilled parameter placeholders
- add unit coverage for PS placeholder replacement and plan monitor EXPLAIN eligibility

Fixes #420

## Verification
- `PYTHONPATH=. python -m pytest test/common/test_fill_sql_with_params.py test/gather/test_gather_plan_monitor_ps_sql.py test/common/test_scene.py -q`
- `black --check -S -l 256 src/common/tool.py src/handler/gather/gather_plan_monitor.py test/common/test_fill_sql_with_params.py test/gather/test_gather_plan_monitor_ps_sql.py`
- `python workflow_data/check_py_files.py .`
- `git diff --check`