### PR TITLE
Remove bc dependency from Debian package build

### DIFF
--- a/ubuntu/build_ubuntu.sh
+++ b/ubuntu/build_ubuntu.sh
@@ -52,7 +52,7 @@ else
     for py in python3.12 python3.11 python3; do
         if command -v $py >/dev/null 2>&1; then
             version=$($py -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-            if [ "$(echo "$version >= 3.11" | bc -l 2>/dev/null || echo 0)" -eq 1 ]; then
+            if $py -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)"; then
                 PYTHON=$py
                 echo "Using Python: $PYTHON (version $version)"
                 break


### PR DESCRIPTION
## Summary
- replace the Debian package build Python version comparison that used `bc -l`
- use the candidate Python interpreter itself to verify Python 3.11+
- confirm there are no remaining direct `bc` command dependencies in check tasks or package scripts

Fixes #232

## Verification
- `bash -n ubuntu/build_ubuntu.sh`
- `rg -n "\|\s*bc\b|\bbc\s+-l\b|command -v bc|/usr/bin/bc" . --glob "!*.pyc" --glob "!__pycache__/**" --glob "!dependencies/**"` returns no matches
- `git diff --check`